### PR TITLE
Fix spinner panic on resume (fixes #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.9] - 2026-01-12
+
+### Fixed
+
+- **Spinner panic on resume** - fixed "send on closed channel" crash when resuming sessions. The spinner's Stop() method is now idempotent, safe to call multiple times (fixes #2).
+
 ## [0.9.8] - 2026-01-12
 
 ### Added

--- a/internal/core/session/spinner.go
+++ b/internal/core/session/spinner.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 )
 
 // Spinner shows a simple spinning animation while waiting
 type Spinner struct {
-	writer  io.Writer
-	message string
-	stop    chan bool
+	writer   io.Writer
+	message  string
+	stop     chan struct{}
+	stopOnce sync.Once
 }
 
 // NewSpinner creates a new spinner with a message
@@ -19,7 +21,7 @@ func NewSpinner(message string) *Spinner {
 	return &Spinner{
 		writer:  os.Stderr,
 		message: message,
-		stop:    make(chan bool),
+		stop:    make(chan struct{}),
 	}
 }
 
@@ -45,8 +47,9 @@ func (s *Spinner) Start() {
 	}()
 }
 
-// Stop stops the spinner and clears the line
+// Stop stops the spinner and clears the line. Safe to call multiple times.
 func (s *Spinner) Stop() {
-	s.stop <- true
-	close(s.stop)
+	s.stopOnce.Do(func() {
+		close(s.stop)
+	})
 }


### PR DESCRIPTION
## Summary
- Fix "send on closed channel" panic when resuming sessions
- Make spinner's Stop() idempotent using sync.Once
- Bump to v0.9.9

The panic occurred when Stop() was called twice - once explicitly on error paths, then again via defer.