### PR TITLE
BLAKE3-based sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -67,6 +68,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/zeebo/blake3 v0.2.4 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
+github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -154,6 +156,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
 golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b h1:M2rDM6z3Fhozi9O7NWsxAkg/yqS/lQJ6PmkyIV3YP+o=
 golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b/go.mod h1:3//PLf8L/X+8b4vuAfHzxeRUl04Adcb341+IGKfnqS8=
 golang.org/x/mod v0.27.0 h1:kb+q2PyFnEADO2IEF935ehFUXlWiNjJWtRNgBLSfbxQ=

--- a/internal/core/importer/importer.go
+++ b/internal/core/importer/importer.go
@@ -1,8 +1,6 @@
 package importer
 
 import (
-	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -15,6 +13,7 @@ import (
 
 	"github.com/neilberkman/ccrider/internal/core/db"
 	"github.com/neilberkman/ccrider/pkg/ccsessions"
+	"github.com/zeebo/blake3"
 )
 
 // Importer handles importing sessions into the database
@@ -29,12 +28,9 @@ func New(database *db.DB) *Importer {
 
 // ImportSession imports a single parsed session, optionally skipping already-imported messages
 // existingMessageCount: number of messages we already have for this session (0 for new sessions)
-func (i *Importer) ImportSession(session *ccsessions.ParsedSession, existingMessageCount int, fileInode, fileDevice uint64) error {
-	// Compute file hash (this is the most expensive operation, done last in ImportDirectory checks)
-	hash, err := computeFileHash(session.FilePath)
-	if err != nil {
-		return fmt.Errorf("failed to hash file: %w", err)
-	}
+// fileHash: pre-computed blake3 hash from ImportDirectory (avoids double-hashing)
+func (i *Importer) ImportSession(session *ccsessions.ParsedSession, existingMessageCount int, fileInode, fileDevice uint64, fileHash string) error {
+	hash := fileHash
 
 	// Begin transaction
 	tx, err := i.db.Begin()
@@ -69,8 +65,7 @@ func (i *Importer) ImportSession(session *ccsessions.ParsedSession, existingMess
 		updatedAt = session.FileMtime
 	}
 
-	// Upsert session - update if this file is newer than existing
-	// NOTE: We set message_count to 0 initially, will update with actual count after filtering messages
+	// Upsert session — hash-only import means we always have current file data
 	_, err = tx.Exec(`
 		INSERT INTO sessions (
 			session_id, project_path, summary, leaf_uuid, cwd,
@@ -79,45 +74,15 @@ func (i *Importer) ImportSession(session *ccsessions.ParsedSession, existingMess
 		) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
 		ON CONFLICT(session_id) DO UPDATE SET
 			project_path = excluded.project_path,
-			summary = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.summary
-				ELSE sessions.summary
-			END,
-			leaf_uuid = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.leaf_uuid
-				ELSE sessions.leaf_uuid
-			END,
-			cwd = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.cwd
-				ELSE sessions.cwd
-			END,
-			updated_at = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.updated_at
-				ELSE sessions.updated_at
-			END,
-			-- message_count is updated after processing messages, not from parsed file
-			file_hash = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.file_hash
-				ELSE sessions.file_hash
-			END,
-			file_size = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.file_size
-				ELSE sessions.file_size
-			END,
-			file_mtime = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.file_mtime
-				ELSE sessions.file_mtime
-			END,
-			file_inode = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.file_inode
-				WHEN sessions.file_inode IS NULL THEN excluded.file_inode
-				ELSE sessions.file_inode
-			END,
-			file_device = CASE
-				WHEN excluded.file_mtime > sessions.file_mtime THEN excluded.file_device
-				WHEN sessions.file_device IS NULL THEN excluded.file_device
-				ELSE sessions.file_device
-			END
+			summary = excluded.summary,
+			leaf_uuid = excluded.leaf_uuid,
+			cwd = excluded.cwd,
+			updated_at = excluded.updated_at,
+			file_hash = excluded.file_hash,
+			file_size = excluded.file_size,
+			file_mtime = excluded.file_mtime,
+			file_inode = excluded.file_inode,
+			file_device = excluded.file_device
 	`,
 		session.SessionID,
 		projectPath,
@@ -236,14 +201,15 @@ func (i *Importer) ImportDirectory(dirPath string, progress ProgressCallback, fo
 			return err
 		}
 		if !info.IsDir() && filepath.Ext(path) == ".jsonl" {
-			// Skip subagent files if requested
+			basename := filepath.Base(path)
+			// Skip cloud sync conflict files
+			if strings.Contains(basename, "Edit conflict") {
+				return nil
+			}
 			if skipSubagents {
-				// Skip files in subagents/ directories
 				if strings.Contains(path, "/subagents/") {
 					return nil
 				}
-				// Skip files named agent-*
-				basename := filepath.Base(path)
 				if strings.HasPrefix(basename, "agent-") {
 					return nil
 				}
@@ -256,18 +222,15 @@ func (i *Importer) ImportDirectory(dirPath string, progress ProgressCallback, fo
 		return 0, fmt.Errorf("failed to walk directory: %w", err)
 	}
 
-	// Pre-load all session metadata for fast lookups (avoids N queries)
-	sessionMetadata := make(map[string]struct {
-		mtime        time.Time
-		size         int64
-		inode        uint64
-		device       uint64
+	// Pre-load session hashes + message counts for fast lookups
+	type sessionMeta struct {
 		messageCount int
 		hash         string
-	})
+	}
+	sessionMetadata := make(map[string]sessionMeta)
 
 	rows, err := i.db.Query(`
-		SELECT session_id, file_mtime, file_size, file_inode, file_device, COALESCE(message_count, 0), COALESCE(file_hash, '')
+		SELECT session_id, COALESCE(message_count, 0), COALESCE(file_hash, '')
 		FROM sessions
 	`)
 	if err != nil {
@@ -276,159 +239,61 @@ func (i *Importer) ImportDirectory(dirPath string, progress ProgressCallback, fo
 
 	for rows.Next() {
 		var sid string
-		var mtimeStr string
-		var size sql.NullInt64
-		var inode sql.NullInt64
-		var device sql.NullInt64
-		var msgCount int
-
-		var hash string
-		if err := rows.Scan(&sid, &mtimeStr, &size, &inode, &device, &msgCount, &hash); err != nil {
+		var meta sessionMeta
+		if err := rows.Scan(&sid, &meta.messageCount, &meta.hash); err != nil {
 			_ = rows.Close()
 			return 0, fmt.Errorf("failed to scan session metadata: %w", err)
 		}
-
-		// Try multiple time formats (DB may have different formats from different sync runs)
-		var mtime time.Time
-		var err error
-
-		// Try ISO 8601 format first (2026-01-24T15:07:52.813484196-08:00)
-		mtime, err = time.Parse(time.RFC3339Nano, mtimeStr)
-		if err != nil {
-			// Try Go time.String() format (2026-01-21 23:38:52.285893225 -0800 PST)
-			mtime, err = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", mtimeStr)
-			if err != nil {
-				// Both formats failed - this shouldn't happen, but log and continue
-				fmt.Printf("WARN: Failed to parse mtime for %s: %v (raw: %s)\n", sid, err, mtimeStr)
-			}
-		}
-
-		sessionMetadata[sid] = struct {
-			mtime        time.Time
-			size         int64
-			inode        uint64
-			device       uint64
-			messageCount int
-			hash         string
-		}{
-			mtime:        mtime,
-			size:         size.Int64,
-			inode:        uint64(inode.Int64),
-			device:       uint64(device.Int64),
-			messageCount: msgCount,
-			hash:         hash,
-		}
+		sessionMetadata[sid] = meta
 	}
 	_ = rows.Close()
 
-	// Import each file with detailed counters
-	var (
-		skipped           = 0
-		failed            = 0
-		skippedMtimeSize  = 0
-		skippedHash       = 0
-		parsed            = 0
-		hashed            = 0
-		imported          = 0
-	)
+	var skipped, failed, imported int
 
 	for _, file := range files {
-		// Get file info for multi-level change detection
-		fileInfo, err := os.Stat(file)
+		sessionID := filepath.Base(file)
+		sessionID = strings.TrimSuffix(sessionID, ".jsonl")
+
+		// blake3 hash is the sole freshness check
+		currentHash, err := computeFileHash(file)
 		if err != nil {
-			// Silently skip files that were deleted between Walk and Stat (race condition)
 			if os.IsNotExist(err) {
 				skipped++
 				continue
 			}
-			// Real error - log it
-			fmt.Printf("WARN: Cannot stat file %s: %v\n", file, err)
-			failed++
-			continue
-		}
-		fileMtime := fileInfo.ModTime()
-		fileSize := fileInfo.Size()
-
-		// Get platform-specific file identity (inode/device on Unix)
-		fileInode, fileDevice, err := getFileIdentity(file)
-		if err != nil {
-			// Failed to get file identity - continue with mtime/size checks only
-			fileInode, fileDevice = 0, 0
-		}
-
-		// Extract session ID from filename
-		sessionID := filepath.Base(file)
-		sessionID = strings.TrimSuffix(sessionID, ".jsonl")
-
-		// Multi-level change detection: Check against pre-loaded metadata
-		metadata, exists := sessionMetadata[sessionID]
-		messageCount := 0
-
-		if exists && !force {
-			messageCount = metadata.messageCount
-
-			// Level 1: Check mtime + size (sufficient to prove file unchanged)
-			// If BOTH match (within 1 second for mtime), file content is guaranteed unchanged
-			// We allow 1s tolerance because mtime precision varies across filesystems
-			mtimeDiff := fileMtime.Sub(metadata.mtime)
-			if mtimeDiff < 0 {
-				mtimeDiff = -mtimeDiff
-			}
-			if !metadata.mtime.IsZero() && mtimeDiff < time.Second && fileSize == metadata.size {
-				// File is unchanged - skip parsing
-				// NOTE: We don't check inode because:
-				// 1. Filesystems can reassign inodes (especially network/cloud storage)
-				// 2. mtime + size is already a perfect cache key
-				// 3. Inode-only changes without mtime change are impossible (OS updates mtime on write)
-				skipped++
-				skippedMtimeSize++
-				continue
-			}
-
-			// Level 4: Check if file is older than DB (clock skew / manipulation)
-			// This is suspicious but not necessarily wrong - continue to parse/hash
-			// The hash check in ImportSession will catch actual changes
-		}
-		// else: new session or force mode - need to import
-
-		// Before parsing, check hash (fast check to avoid expensive parse)
-		currentHash, err := computeFileHash(file)
-		hashed++
-		if err != nil {
 			fmt.Printf("WARN: Cannot hash file %s: %v\n", file, err)
 			failed++
 			continue
 		}
 
-		// If we have this session and hash matches, skip (file unchanged despite mtime/size/inode differences)
+		metadata, exists := sessionMetadata[sessionID]
+		messageCount := 0
+
+		if exists && !force && metadata.hash == currentHash {
+			skipped++
+			continue
+		}
 		if exists {
-			var dbHash string
-			err := i.db.QueryRow(`SELECT file_hash FROM sessions WHERE session_id = ?`, sessionID).Scan(&dbHash)
-			if err == nil && dbHash == currentHash {
-				// Hash matches - file is actually unchanged
-				skipped++
-				skippedHash++
-				continue
-			}
+			messageCount = metadata.messageCount
 		}
 
-		// Hash is different or new file - need to parse and import
+		// Hash differs or new file — parse and import
 		session, err := ccsessions.ParseFile(file)
-		parsed++
 		if err != nil {
 			fmt.Printf("WARN: Cannot parse file %s: %v\n", file, err)
 			failed++
 			continue
 		}
 
-		if err := i.ImportSession(session, messageCount, fileInode, fileDevice); err != nil {
+		fileInode, fileDevice, _ := getFileIdentity(file)
+
+		if err := i.ImportSession(session, messageCount, fileInode, fileDevice, currentHash); err != nil {
 			fmt.Printf("WARN: Cannot import session %s: %v\n", sessionID, err)
 			failed++
 			continue
 		}
 		imported++
 
-		// Update progress
 		if progress != nil {
 			firstMsg := ""
 			if len(session.Messages) > 0 {
@@ -441,7 +306,6 @@ func (i *Importer) ImportDirectory(dirPath string, progress ProgressCallback, fo
 		}
 	}
 
-	// Report summary only if there were failures
 	if failed > 0 {
 		fmt.Printf("\nImport completed with %d failures (see warnings above)\n", failed)
 	}
@@ -458,12 +322,12 @@ func computeFileHash(path string) (string, error) {
 		_ = file.Close()
 	}()
 
-	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
+	h := blake3.New()
+	if _, err := io.Copy(h, file); err != nil {
 		return "", err
 	}
 
-	return hex.EncodeToString(hash.Sum(nil)), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // extractProjectInitiationPath finds the FIRST non-empty CWD from messages

--- a/internal/core/importer/importer_test.go
+++ b/internal/core/importer/importer_test.go
@@ -38,12 +38,15 @@ func TestImportSession(t *testing.T) {
 	// Get file identity for the test file
 	inode, device, err := getFileIdentity(session.FilePath)
 	if err != nil {
-		// OK if not available, use 0
 		inode, device = 0, 0
 	}
 
-	// Import it
-	err = imp.ImportSession(session, 0, inode, device)
+	hash, err := computeFileHash(session.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = imp.ImportSession(session, 0, inode, device, hash)
 	if err != nil {
 		t.Fatalf("ImportSession() error = %v", err)
 	}
@@ -97,16 +100,19 @@ func TestImportSession_ResumedSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get file identity
 	inode, device, _ := getFileIdentity(session1.FilePath)
+	hash, err := computeFileHash(session1.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err = imp.ImportSession(session1, 0, inode, device)
+	err = imp.ImportSession(session1, 0, inode, device, hash)
 	if err != nil {
 		t.Fatalf("ImportSession() error = %v", err)
 	}
 
-	// Import the same session again (simulating resumed session)
-	err = imp.ImportSession(session1, 0, inode, device)
+	// Import same session again (simulating resumed session)
+	err = imp.ImportSession(session1, 0, inode, device, hash)
 	if err != nil {
 		t.Fatalf("ImportSession() second import error = %v", err)
 	}
@@ -161,10 +167,13 @@ func TestImportSession_AgentSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get file identity
 	inode, device, _ := getFileIdentity(session.FilePath)
+	hash, err := computeFileHash(session.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err = imp.ImportSession(session, 0, inode, device)
+	err = imp.ImportSession(session, 0, inode, device, hash)
 	if err != nil {
 		t.Fatalf("ImportSession() error = %v", err)
 	}

--- a/internal/core/importer/progress.go
+++ b/internal/core/importer/progress.go
@@ -66,5 +66,5 @@ func (p *ProgressReporter) Update(sessionSummary string, firstMsg string) {
 // Finish completes the progress display
 func (p *ProgressReporter) Finish() {
 	elapsed := time.Since(p.startTime)
-	_, _ = fmt.Fprintf(p.writer, "\nCompleted: Imported %d sessions in %s\n", p.total, elapsed.Round(time.Millisecond))
+	_, _ = fmt.Fprintf(p.writer, "\nCompleted: Scanned %d sessions in %s\n", p.total, elapsed.Round(time.Millisecond))
 }

--- a/internal/core/models/session.go
+++ b/internal/core/models/session.go
@@ -20,7 +20,7 @@ type Session struct {
 	Version      string // Claude Code version
 	ImportedAt   time.Time
 	LastSyncedAt time.Time
-	FileHash     string // SHA256 for change detection
+	FileHash     string // blake3 for change detection
 	FileSize     int64
 	FileMtime    time.Time
 }

--- a/internal/interface/cli/sync.go
+++ b/internal/interface/cli/sync.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/neilberkman/ccrider/internal/core/db"
 	"github.com/neilberkman/ccrider/internal/core/importer"
@@ -60,20 +61,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 		_ = database.Close()
 	}()
 
-	// Check if we need one-time migration sync
-	if !syncForce {
-		needsMigrationSync, err := database.NeedsMigrationSync()
-		if err != nil {
-			return fmt.Errorf("failed to check migration status: %w", err)
-		}
-		if needsMigrationSync {
-			fmt.Println("⚡ One-time optimization: Populating file tracking data for fast incremental syncs...")
-			fmt.Println("   This will take a minute but makes future syncs much faster.")
-			fmt.Println()
-			syncForce = true
-		}
-	}
-
 	// Count total files for progress
 	total, err := countJSONLFiles(sourcePath)
 	if err != nil {
@@ -120,6 +107,14 @@ func countJSONLFiles(dirPath string) (int, error) {
 			return err
 		}
 		if !info.IsDir() && filepath.Ext(path) == ".jsonl" {
+			basename := filepath.Base(path)
+			// Match ImportDirectory filters
+			if strings.Contains(basename, "Edit conflict") {
+				return nil
+			}
+			if strings.Contains(path, "/subagents/") || strings.HasPrefix(basename, "agent-") {
+				return nil
+			}
 			count++
 		}
 		return nil


### PR DESCRIPTION
Kinda opinionated, but BLAKE3-based sync freshness works much more reliably for me than the mtime+size+hash cascade. My sessions live on a cloud drive which causes weird mtime drift and sync conflict files, `ccrider sync` would import a random number of sessions each run no matter what. Fast hash as the sole freshness check is sufficient since the bottleneck is SQLite, not hashing. BLAKE3 on Apple Silicon is ridiculously fast.

Also filters out cloud sync conflict files that were silently polluting the DB.

Been using this for a couple of weeks, all good.