### PR TITLE
Add GitHub Copilot CLI support + provider-aware resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 [![Homebrew](https://img.shields.io/badge/homebrew-neilberkman%2Ftap-orange)](https://github.com/neilberkman/homebrew-tap)
 [![Show HN](https://img.shields.io/badge/Show%20HN-black?logo=ycombinator)](https://news.ycombinator.com/item?id=46512501)
 
-Search, browse, and resume your Claude Code and Codex CLI sessions, plus MCP server to remember past context.
+Search, browse, and resume your Claude Code, Codex CLI, and GitHub Copilot CLI sessions, plus MCP server to remember past context.
 
 When your coding agent forgets, tell it: _[see what you have done](#the-king)_.
 
 ## Why ccrider?
 
-You've got months of coding agent sessions sitting in `~/.claude/projects/` and `~/.codex/sessions/`. Finding that conversation where you fixed the authentication bug? Good luck grepping through nested JSON files.
+You've got months of coding agent sessions sitting in `~/.claude/projects/`, `~/.codex/sessions/`, and `~/.copilot/`. Finding that conversation where you fixed the authentication bug? Good luck grepping through nested JSON files.
 
-ccrider indexes Claude Code and Codex CLI sessions into a single searchable database, with a TUI browser, CLI search, and an MCP server so your agent can search past sessions too.
+ccrider indexes Claude Code, Codex CLI, and GitHub Copilot CLI sessions into a single searchable database, with a TUI browser, CLI search, and an MCP server so your agent can search past sessions too.
 
 ```bash
-# Import sessions from Claude Code and Codex CLI
+# Import sessions from Claude Code, Codex CLI, and Copilot CLI
 ccrider sync
 
 # Launch the TUI - browse, search, resume
@@ -27,7 +27,7 @@ ccrider tui
 ccrider search "authentication bug"
 ```
 
-Stay in your terminal. Find any conversation. Resume where you left off. Codex sessions are tagged with `[codex]` in the TUI for easy identification.
+Stay in your terminal. Find any conversation. Resume where you left off. Codex and Copilot sessions are tagged with `[codex]` and `[copilot]` in the TUI for easy identification.
 
 **Installation:**
 
@@ -96,7 +96,7 @@ ccrider sync         # Import new sessions from all providers
 ccrider sync --full  # Re-import everything
 ```
 
-Automatically discovers Claude Code (`~/.claude/projects/`) and Codex CLI (`~/.codex/sessions/`) sessions. Detects ongoing sessions and imports new messages without re-processing everything.
+Automatically discovers Claude Code (`~/.claude/projects/`), Codex CLI (`~/.codex/sessions/`), and GitHub Copilot CLI (`~/.copilot/session-state/`) sessions. Detects ongoing sessions and imports new messages without re-processing everything.
 
 ---
 
@@ -145,7 +145,7 @@ Add to your config (`~/Library/Application Support/Claude/claude_desktop_config.
 - **get_session_messages** - Get messages from a session (supports tail mode, context around search matches)
 - **generate_session_anchor** - Generate a unique phrase to tag your session for later retrieval
 
-All tools support a `provider` parameter to filter by `claude` or `codex`. The MCP server provides read-only access to your session database. Your conversations stay local.
+All tools support a `provider` parameter to filter by `claude`, `codex`, or `copilot`. The MCP server provides read-only access to your session database. Your conversations stay local.
 
 ---
 
@@ -201,7 +201,7 @@ Other coding agent session tools are broken:
 ccrider fixes this with:
 
 - 100% schema coverage - parses all message types correctly
-- Multi-provider - Claude Code and Codex CLI in one database
+- Multi-provider - Claude Code, Codex CLI, and GitHub Copilot CLI in one database
 - SQLite FTS5 search - fast, powerful full-text search
 - Single binary - no npm, no pip, no dependencies
 - Native resume - one keystroke to resume sessions
@@ -229,6 +229,7 @@ internal/
 pkg/
   ccsessions/         # Claude Code session parser (public API)
   codexsessions/      # Codex CLI session parser (public API)
+  copilotsessions/    # GitHub Copilot CLI session parser (public API)
 ```
 
 ### Quick Build

--- a/cmd/ccrider/mcp/server.go
+++ b/cmd/ccrider/mcp/server.go
@@ -22,7 +22,7 @@ type SearchSessionsArgs struct {
 	Query            string `json:"query" jsonschema:"description=Search term to match against message content,required"`
 	Limit            int    `json:"limit,omitempty" jsonschema:"description=Max number of sessions to return (default: 10)"`
 	Project          string `json:"project,omitempty" jsonschema:"description=Filter by project path"`
-	Provider         string `json:"provider,omitempty" jsonschema:"description=Filter by provider (claude or codex)"`
+	Provider         string `json:"provider,omitempty" jsonschema:"description=Filter by provider (claude, codex, or copilot)"`
 	CurrentSessionID string `json:"current_session_id,omitempty" jsonschema:"description=Current session ID to search within (searches only this session)"`
 	ExcludeCurrent   bool   `json:"exclude_current,omitempty" jsonschema:"description=Exclude current session from results (searches only other sessions)"`
 	AfterDate        string `json:"after_date,omitempty" jsonschema:"description=Only sessions updated after this date (ISO 8601 format, e.g. 2025-01-01)"`
@@ -35,7 +35,7 @@ type SearchSessionsArgs struct {
 type ListRecentSessionsArgs struct {
 	Limit    int    `json:"limit,omitempty" jsonschema:"description=Max sessions to return (default: 20)"`
 	Project  string `json:"project,omitempty" jsonschema:"description=Filter by project path"`
-	Provider string `json:"provider,omitempty" jsonschema:"description=Filter by provider (claude or codex)"`
+	Provider string `json:"provider,omitempty" jsonschema:"description=Filter by provider (claude, codex, or copilot)"`
 }
 
 // GetSessionMessagesArgs defines arguments for the get_session_messages tool
@@ -148,7 +148,7 @@ func StartServer(dbPath string) error {
 		mcp.WithBoolean("exact_match",
 			mcp.Description("If true, treats the query as an exact phrase match (auto-quoted). Use this instead of trying to add quotes yourself.")),
 		mcp.WithString("provider",
-			mcp.Description("Filter by provider (e.g. \"claude\" or \"codex\")")),
+			mcp.Description("Filter by provider (e.g. \"claude\", \"codex\", or \"copilot\")")),
 	)
 	s.AddTool(searchTool, makeSearchSessionsHandler(database))
 
@@ -164,7 +164,7 @@ func StartServer(dbPath string) error {
 		mcp.WithString("project",
 			mcp.Description("Filter by project path")),
 		mcp.WithString("provider",
-			mcp.Description("Filter by provider (e.g. \"claude\" or \"codex\")")),
+			mcp.Description("Filter by provider (e.g. \"claude\", \"codex\", or \"copilot\")")),
 	)
 	s.AddTool(listTool, makeListRecentSessionsHandler(database))
 

--- a/internal/core/db/migrations.go
+++ b/internal/core/db/migrations.go
@@ -1,5 +1,10 @@
 package db
 
+import (
+	"database/sql"
+	"strings"
+)
+
 // migrate runs any needed migrations for existing databases
 func (db *DB) migrate() error {
 	// Migration 1: Add llm_summary columns to sessions table
@@ -24,6 +29,11 @@ func (db *DB) migrate() error {
 
 	// Migration 5: Invalidate Codex sessions so they re-import with response_item parsing
 	if err := db.migration005ReimportCodexSessions(); err != nil {
+		return err
+	}
+
+	// Migration 6: Fix FTS sync triggers for external-content tables and rebuild
+	if err := db.migration006FixFTSTriggers(); err != nil {
 		return err
 	}
 
@@ -208,6 +218,57 @@ func (db *DB) migration005ReimportCodexSessions() error {
 	}
 
 	return tx.Commit()
+}
+
+// migration006FixFTSTriggers replaces the FTS sync triggers with the
+// external-content-correct form and rebuilds the FTS indexes.
+//
+// messages_fts/_code are external-content FTS5 tables. The original
+// messages_ad/messages_au triggers used a plain DELETE / UPDATE on the FTS
+// tables, which does not remove old terms from an external-content index —
+// stale terms linger. This was latent (nothing updated message text in place)
+// until enumerated providers (Copilot) began re-importing edited message text,
+// at which point search would match both the old and new text. The rebuild
+// clears any stale terms left behind by the old triggers.
+func (db *DB) migration006FixFTSTriggers() error {
+	var triggerSQL string
+	err := db.conn.QueryRow(`
+		SELECT COALESCE(sql, '') FROM sqlite_master
+		WHERE type='trigger' AND name='messages_au'
+	`).Scan(&triggerSQL)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// Fresh databases already have the corrected trigger from initSchema.
+	if !strings.Contains(triggerSQL, "UPDATE messages_fts") {
+		return nil
+	}
+
+	stmts := []string{
+		`DROP TRIGGER IF EXISTS messages_ad`,
+		`DROP TRIGGER IF EXISTS messages_au`,
+		`CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+			INSERT INTO messages_fts_code(messages_fts_code, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+		END`,
+		`CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+			INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+			INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
+			INSERT INTO messages_fts_code(messages_fts_code, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+			INSERT INTO messages_fts_code(rowid, text_content) VALUES (new.id, new.text_content);
+		END`,
+		`INSERT INTO messages_fts(messages_fts) VALUES('rebuild')`,
+		`INSERT INTO messages_fts_code(messages_fts_code) VALUES('rebuild')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.conn.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (db *DB) migration004AddProviderColumn() error {

--- a/internal/core/db/schema.go
+++ b/internal/core/db/schema.go
@@ -100,20 +100,25 @@ func (db *DB) initSchema() error {
 		tokenize='unicode61'
 	);
 
-	-- Triggers to keep FTS in sync
+	-- Triggers to keep FTS in sync.
+	-- messages_fts/_code are external-content FTS5 tables, so delete/update must
+	-- use the special 'delete' command with the OLD row values; a plain DELETE or
+	-- UPDATE on the FTS table leaves stale terms in the index.
 	CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
 		INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
 		INSERT INTO messages_fts_code(rowid, text_content) VALUES (new.id, new.text_content);
 	END;
 
 	CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
-		DELETE FROM messages_fts WHERE rowid = old.id;
-		DELETE FROM messages_fts_code WHERE rowid = old.id;
+		INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+		INSERT INTO messages_fts_code(messages_fts_code, rowid, text_content) VALUES ('delete', old.id, old.text_content);
 	END;
 
 	CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-		UPDATE messages_fts SET text_content = new.text_content WHERE rowid = new.id;
-		UPDATE messages_fts_code SET text_content = new.text_content WHERE rowid = new.id;
+		INSERT INTO messages_fts(messages_fts, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+		INSERT INTO messages_fts(rowid, text_content) VALUES (new.id, new.text_content);
+		INSERT INTO messages_fts_code(messages_fts_code, rowid, text_content) VALUES ('delete', old.id, old.text_content);
+		INSERT INTO messages_fts_code(rowid, text_content) VALUES (new.id, new.text_content);
 	END;
 	`
 

--- a/internal/core/importer/importer.go
+++ b/internal/core/importer/importer.go
@@ -157,7 +157,19 @@ func (i *Importer) ImportSession(session *ccsessions.ParsedSession, existingMess
 				content, text_content, timestamp, sequence,
 				is_sidechain, cwd, git_branch, version
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(uuid) DO UPDATE SET session_id = excluded.session_id
+			ON CONFLICT(uuid) DO UPDATE SET
+				session_id = excluded.session_id,
+				parent_uuid = excluded.parent_uuid,
+				type = excluded.type,
+				sender = excluded.sender,
+				content = excluded.content,
+				text_content = excluded.text_content,
+				timestamp = excluded.timestamp,
+				sequence = excluded.sequence,
+				is_sidechain = excluded.is_sidechain,
+				cwd = excluded.cwd,
+				git_branch = excluded.git_branch,
+				version = excluded.version
 		`,
 			msg.UUID,
 			sessionDBID,
@@ -368,6 +380,81 @@ func (i *Importer) ImportDirectory(dirPath string, progress ProgressCallback, fo
 	}
 
 	return skipped, nil
+}
+
+// ImportEnumerated imports a slice of already-parsed sessions from a
+// database-backed provider (e.g. Copilot) that has no per-session files to walk.
+//
+// Incremental sync uses a synthetic content hash (derived from the session's
+// last-updated time and message count) in place of a file hash: unchanged
+// sessions are skipped. Returns the number of skipped sessions.
+func (i *Importer) ImportEnumerated(sessions []*ccsessions.ParsedSession, progress ProgressCallback, force bool, provider string) (int, error) {
+	// Pre-load existing session hashes for fast skip checks.
+	existingHash := make(map[string]string)
+
+	rows, err := i.db.Query(`SELECT session_id, COALESCE(file_hash, '') FROM sessions`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load session metadata: %w", err)
+	}
+	for rows.Next() {
+		var sid, hash string
+		if err := rows.Scan(&sid, &hash); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("failed to scan session metadata: %w", err)
+		}
+		existingHash[sid] = hash
+	}
+	_ = rows.Close()
+
+	var skipped, failed int
+
+	for _, session := range sessions {
+		sessionID := filepath.Base(session.FilePath)
+		sessionID = strings.TrimSuffix(sessionID, filepath.Ext(sessionID))
+
+		hash := enumeratedSessionHash(sessionID, session)
+
+		if !force && existingHash[sessionID] == hash {
+			skipped++
+			continue
+		}
+
+		// Pass existingMessageCount=0: messages carry stable, content-addressed
+		// UUIDs, so ImportSession's ON CONFLICT(uuid) dedups already-imported
+		// messages while still inserting real new ones without relying on
+		// append-only ordering (which breaks when an earlier turn is backfilled).
+		if err := i.ImportSession(session, 0, 0, 0, hash, provider); err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: Cannot import session %s: %v\n", sessionID, err)
+			failed++
+			continue
+		}
+
+		if progress != nil {
+			firstMsg := ""
+			if len(session.Messages) > 0 {
+				firstMsg = session.Messages[0].TextContent
+				if len(firstMsg) > 100 {
+					firstMsg = firstMsg[:97] + "..."
+				}
+			}
+			progress.Update(session.Summary, firstMsg)
+		}
+	}
+
+	if failed > 0 {
+		fmt.Fprintf(os.Stderr, "\nImport completed with %d failures (see warnings above)\n", failed)
+	}
+
+	return skipped, nil
+}
+
+// enumeratedSessionHash produces a change-detection hash for a database-backed
+// session. It changes whenever the session's last-updated time or message count
+// changes, which is sufficient to detect new turns on an existing session.
+func enumeratedSessionHash(sessionID string, session *ccsessions.ParsedSession) string {
+	h := blake3.New()
+	_, _ = fmt.Fprintf(h, "%s|%d|%d", sessionID, session.FileMtime.UnixNano(), len(session.Messages))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func computeFileHash(path string) (string, error) {

--- a/internal/core/importer/importer_test.go
+++ b/internal/core/importer/importer_test.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/neilberkman/ccrider/internal/core/db"
 	"github.com/neilberkman/ccrider/pkg/ccsessions"
@@ -292,5 +293,88 @@ func TestImportSession_ProviderStoredForClaude(t *testing.T) {
 	}
 	if provider != "claude" {
 		t.Errorf("Expected provider 'claude', got %q", provider)
+	}
+}
+
+// TestImportEnumeratedRefreshesEditedText verifies that when an enumerated
+// provider (e.g. Copilot) rewrites a message's text in place — same UUID, new
+// content — a re-sync updates both the stored text and the FTS index, rather
+// than discarding the new text at the ON CONFLICT(uuid) clause.
+func TestImportEnumeratedRefreshesEditedText(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "test-edit-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+	_ = tmpfile.Close()
+
+	database, err := db.New(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	imp := New(database)
+
+	makeSession := func(text string, mtime time.Time) *ccsessions.ParsedSession {
+		return &ccsessions.ParsedSession{
+			SessionID: "copilot-session",
+			Summary:   "edit test",
+			FilePath:  "/tmp/copilot/copilot-session.copilot",
+			FileMtime: mtime,
+			Messages: []ccsessions.ParsedMessage{{
+				UUID:        "msg-stable-uuid",
+				Type:        "assistant",
+				Sender:      "assistant",
+				TextContent: text,
+				Timestamp:   mtime,
+				Sequence:    1,
+			}},
+		}
+	}
+
+	// Initial import.
+	t0 := time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC)
+	if _, err := imp.ImportEnumerated([]*ccsessions.ParsedSession{makeSession("aardvark original", t0)}, nil, false, "copilot"); err != nil {
+		t.Fatalf("initial import: %v", err)
+	}
+
+	textContent := func() string {
+		var got string
+		if err := database.QueryRow(`SELECT text_content FROM messages WHERE uuid = ?`, "msg-stable-uuid").Scan(&got); err != nil {
+			t.Fatalf("query text: %v", err)
+		}
+		return got
+	}
+	ftsMatches := func(term string) int {
+		var n int
+		if err := database.QueryRow(`SELECT count(*) FROM messages_fts WHERE messages_fts MATCH ?`, term).Scan(&n); err != nil {
+			t.Fatalf("query fts %q: %v", term, err)
+		}
+		return n
+	}
+
+	if got := textContent(); got != "aardvark original" {
+		t.Fatalf("after initial import text = %q", got)
+	}
+	if ftsMatches("aardvark") != 1 || ftsMatches("beluga") != 0 {
+		t.Fatalf("initial FTS state wrong: aardvark=%d beluga=%d", ftsMatches("aardvark"), ftsMatches("beluga"))
+	}
+
+	// Re-import the same UUID with rewritten text and a newer mtime (so the
+	// session's change-detection hash differs and the import actually runs).
+	t1 := t0.Add(time.Hour)
+	if _, err := imp.ImportEnumerated([]*ccsessions.ParsedSession{makeSession("beluga rewritten", t1)}, nil, false, "copilot"); err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+
+	if got := textContent(); got != "beluga rewritten" {
+		t.Errorf("after re-import text = %q, want %q (edit was discarded)", got, "beluga rewritten")
+	}
+	if ftsMatches("beluga") != 1 {
+		t.Errorf("FTS does not match new text 'beluga' after edit")
+	}
+	if ftsMatches("aardvark") != 0 {
+		t.Errorf("FTS still matches stale text 'aardvark' after edit")
 	}
 }

--- a/internal/core/importer/sync.go
+++ b/internal/core/importer/sync.go
@@ -3,21 +3,33 @@ package importer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/neilberkman/ccrider/pkg/ccsessions"
 	"github.com/neilberkman/ccrider/pkg/codexsessions"
+	"github.com/neilberkman/ccrider/pkg/copilotsessions"
 )
 
-// Source describes a session directory to import.
+// EnumerateFunc returns all parsed sessions for a database/event-log-backed
+// provider (e.g. Copilot) that does not store one JSONL file per session in a
+// flat, walkable directory.
+type EnumerateFunc func() ([]*ccsessions.ParsedSession, error)
+
+// Source describes a session source to import.
+//
+// File-based providers (Claude, Codex) set Path + ParseFn and are imported by
+// walking a directory of JSONL files. Enumerated providers (Copilot) set
+// EnumerateFn instead, which yields all sessions in one call.
 type Source struct {
 	Path          string
 	ParseFn       ParseFunc
+	EnumerateFn   EnumerateFunc
 	Provider      string
 	SkipSubagents bool
 }
 
-// DefaultSources returns the standard import sources (Claude + Codex).
-// Codex is only included if its directory exists.
+// DefaultSources returns the standard import sources (Claude + Codex + Copilot).
+// Codex and Copilot are only included if their data exists on disk.
 func DefaultSources() []Source {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -43,13 +55,104 @@ func DefaultSources() []Source {
 		})
 	}
 
+	copilotStateDir := copilotsessions.DefaultStateDir()
+	if copilotStateDir != "" {
+		if _, err := os.Stat(copilotStateDir); err == nil {
+			sources = append(sources, Source{
+				Path:     copilotStateDir,
+				Provider: "copilot",
+				EnumerateFn: func() ([]*ccsessions.ParsedSession, error) {
+					return copilotsessions.ParseAll(copilotStateDir)
+				},
+			})
+		}
+	}
+
 	return sources
+}
+
+// PreparedSource bundles a source's total unit-of-work count with the action
+// that imports it. Computing the count and choosing the import strategy
+// (walk a directory vs enumerate sessions) is business logic shared by every
+// interface, so it lives here rather than being re-derived in the CLI and TUI.
+type PreparedSource struct {
+	Provider string
+	Path     string
+	Total    int
+	run      func(progress ProgressCallback, force bool) (skipped int, err error)
+}
+
+// Run imports the prepared source, reporting progress, and returns the number
+// of skipped (unchanged) units.
+func (p PreparedSource) Run(progress ProgressCallback, force bool) (int, error) {
+	return p.run(progress, force)
+}
+
+// PrepareSource resolves a Source into its work count and import action. For
+// enumerated sources the sessions are read once here and reused by Run, so the
+// underlying store/event logs are not parsed twice.
+func (i *Importer) PrepareSource(src Source) (PreparedSource, error) {
+	if src.EnumerateFn != nil {
+		sessions, err := src.EnumerateFn()
+		if err != nil {
+			return PreparedSource{}, err
+		}
+		return PreparedSource{
+			Provider: src.Provider,
+			Path:     src.Path,
+			Total:    len(sessions),
+			run: func(progress ProgressCallback, force bool) (int, error) {
+				return i.ImportEnumerated(sessions, progress, force, src.Provider)
+			},
+		}, nil
+	}
+
+	total, err := CountJSONLFiles(src.Path, src.SkipSubagents)
+	if err != nil {
+		return PreparedSource{}, err
+	}
+	return PreparedSource{
+		Provider: src.Provider,
+		Path:     src.Path,
+		Total:    total,
+		run: func(progress ProgressCallback, force bool) (int, error) {
+			return i.ImportDirectory(src.Path, progress, force, src.SkipSubagents, src.ParseFn, src.Provider)
+		},
+	}, nil
+}
+
+// CountJSONLFiles counts importable .jsonl files under dirPath, applying the
+// same subagent/edit-conflict exclusions ImportDirectory uses.
+func CountJSONLFiles(dirPath string, skipSubagents bool) (int, error) {
+	count := 0
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || filepath.Ext(path) != ".jsonl" {
+			return nil
+		}
+		basename := filepath.Base(path)
+		if strings.Contains(basename, "Edit conflict") {
+			return nil
+		}
+		if skipSubagents && (strings.Contains(path, "/subagents/") || strings.HasPrefix(basename, "agent-")) {
+			return nil
+		}
+		count++
+		return nil
+	})
+	return count, err
 }
 
 // SyncAll imports from all default sources. Silent (nil progress) for background use.
 func (i *Importer) SyncAll(force bool) error {
 	for _, src := range DefaultSources() {
-		if _, err := i.ImportDirectory(src.Path, nil, force, src.SkipSubagents, src.ParseFn, src.Provider); err != nil {
+		prepared, err := i.PrepareSource(src)
+		if err != nil {
+			return err
+		}
+		if _, err := prepared.Run(nil, force); err != nil {
 			return err
 		}
 	}

--- a/internal/core/session/launch.go
+++ b/internal/core/session/launch.go
@@ -21,16 +21,26 @@ func ResolveWorkingDir(projectPath, lastCwd string) string {
 }
 
 // ValidateClaudeRunnable checks if 'claude' command can run from the given directory.
-// This catches common issues like version manager (asdf/mise) failures before launching.
-// Returns nil if claude is runnable, or a descriptive error with suggested fixes.
+// Retained for callers that only ever resume Claude sessions; delegates to
+// ValidateRunnable with the Claude provider.
 func ValidateClaudeRunnable(workDir string) error {
+	return ValidateRunnable(ProviderClaude, workDir)
+}
+
+// ValidateRunnable checks if the resume binary for the given provider can run
+// from the given directory. This catches common issues like version manager
+// (asdf/mise) failures before launching. Returns nil if runnable, or a
+// descriptive error with suggested fixes.
+func ValidateRunnable(provider, workDir string) error {
+	binary := ResumeBinary(provider)
+
 	shell := os.Getenv("SHELL")
 	if shell == "" {
 		shell = "/bin/bash"
 	}
 
-	// Run 'claude --version' through a login shell to simulate actual launch conditions
-	cmd := exec.Command(shell, "-l", "-c", "claude --version")
+	// Run '<binary> --version' through a login shell to simulate actual launch conditions
+	cmd := exec.Command(shell, "-l", "-c", binary+" --version")
 	if workDir != "" {
 		cmd.Dir = workDir
 	}
@@ -51,7 +61,7 @@ func ValidateClaudeRunnable(workDir string) error {
 	if strings.Contains(stderrStr, "No version is set for command") ||
 		strings.Contains(stderrStr, "not installed") ||
 		strings.Contains(stderrStr, ".tool-versions") {
-		return fmt.Errorf(`claude command failed in %s
+		return fmt.Errorf(`%s command failed in %s
 
 %s
 This is typically caused by a version manager (asdf/mise/nvm) configuration issue.
@@ -59,27 +69,39 @@ This is typically caused by a version manager (asdf/mise/nvm) configuration issu
 Suggested fixes:
   1. Install the required nodejs version: asdf install nodejs <version>
   2. Or set a global nodejs version: asdf global nodejs <version>
-  3. Or remove/update the .tool-versions file in the project`, workDir, strings.TrimSpace(stderrStr))
+  3. Or remove/update the .tool-versions file in the project`, binary, workDir, strings.TrimSpace(stderrStr))
 	}
 
 	// Check for command not found
 	if strings.Contains(stderrStr, "command not found") ||
 		strings.Contains(stderrStr, "not found") {
-		return fmt.Errorf(`claude command not found in %s
+		return fmt.Errorf(`%s command not found in %s
 
 %s
 Suggested fixes:
-  1. Install Claude Code: npm install -g @anthropic-ai/claude-code
-  2. Ensure your PATH includes the claude binary
-  3. Check that your shell profile loads correctly`, workDir, strings.TrimSpace(stderrStr))
+  1. Install %s and ensure your PATH includes the %s binary
+  2. Check that your shell profile loads correctly`, binary, workDir, strings.TrimSpace(stderrStr), providerDisplayName(provider), binary)
 	}
 
 	// Generic failure
 	if stderrStr != "" {
-		return fmt.Errorf("claude command failed in %s:\n%s", workDir, strings.TrimSpace(stderrStr))
+		return fmt.Errorf("%s command failed in %s:\n%s", binary, workDir, strings.TrimSpace(stderrStr))
 	}
 
-	return fmt.Errorf("claude command failed in %s: %w", workDir, err)
+	return fmt.Errorf("%s command failed in %s: %w", binary, workDir, err)
+}
+
+// providerDisplayName returns a human-friendly name for the provider's CLI,
+// including install guidance where useful.
+func providerDisplayName(provider string) string {
+	switch provider {
+	case ProviderCodex:
+		return "Codex CLI"
+	case ProviderCopilot:
+		return "GitHub Copilot CLI"
+	default:
+		return "Claude Code (npm install -g @anthropic-ai/claude-code)"
+	}
 }
 
 // SessionFileExists checks if the Claude Code session file exists on disk.

--- a/internal/core/session/resume.go
+++ b/internal/core/session/resume.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// codexRolloutUUID matches the trailing UUID in a Codex rollout filename, e.g.
+// "rollout-2026-06-04T14-40-56-019e93f0-3efe-7742-9598-bb06b36fb25a".
+var codexRolloutUUID = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// codexResumeID returns the id that `codex resume` expects. ccrider stores Codex
+// sessions under their rollout filename (e.g. "rollout-<timestamp>-<uuid>"), but
+// codex resumes by the bare session UUID. If the stored id carries a trailing
+// UUID, extract it; otherwise pass it through unchanged.
+func codexResumeID(sessionID string) string {
+	if m := codexRolloutUUID.FindString(sessionID); m != "" {
+		return m
+	}
+	return sessionID
+}
+
+// Provider identifiers. These match the values stored in the sessions.provider
+// column by the importer.
+const (
+	ProviderClaude  = "claude"
+	ProviderCodex   = "codex"
+	ProviderCopilot = "copilot"
+)
+
+// ResumeBinary returns the CLI executable used to resume a session for the
+// given provider. Unknown/empty providers default to Claude.
+func ResumeBinary(provider string) string {
+	switch provider {
+	case ProviderCodex:
+		return "codex"
+	case ProviderCopilot:
+		return "copilot"
+	default:
+		return "claude"
+	}
+}
+
+// ResumeSpec describes how to resume a session for a given provider.
+//
+// Prefix is the shell command up to (but excluding) any initial prompt
+// argument. Callers append their own prompt handling so that prompt escaping
+// (a shell concern) stays at the call site, e.g. a single-quoted literal or a
+// "$(cat tmpfile)" command substitution.
+type ResumeSpec struct {
+	Binary string
+	Prefix string
+	// AcceptsPrompt reports whether an initial prompt may be appended to Prefix
+	// as a positional argument. Copilot's interactive resume takes no prompt.
+	AcceptsPrompt bool
+}
+
+// BuildResumeSpec returns provider-specific resume invocation details.
+// claudeFlags are only applied for the Claude CLI.
+func BuildResumeSpec(provider, sessionID string, fork bool, claudeFlags []string) ResumeSpec {
+	switch provider {
+	case ProviderCodex:
+		// codex resume <id> [prompt]; forking uses `codex fork <id> [prompt]`.
+		verb := "resume"
+		if fork {
+			verb = "fork"
+		}
+		return ResumeSpec{
+			Binary:        "codex",
+			Prefix:        fmt.Sprintf("codex %s %s", verb, codexResumeID(sessionID)),
+			AcceptsPrompt: true,
+		}
+	case ProviderCopilot:
+		// copilot --resume=<id>; interactive resume has no positional prompt.
+		return ResumeSpec{
+			Binary:        "copilot",
+			Prefix:        fmt.Sprintf("copilot --resume=%s", sessionID),
+			AcceptsPrompt: false,
+		}
+	default:
+		flags := ""
+		if len(claudeFlags) > 0 {
+			flags = " " + strings.Join(claudeFlags, " ")
+		}
+		prefix := fmt.Sprintf("claude%s --resume %s", flags, sessionID)
+		if fork {
+			prefix += " --fork-session"
+		}
+		return ResumeSpec{
+			Binary:        "claude",
+			Prefix:        prefix,
+			AcceptsPrompt: true,
+		}
+	}
+}
+
+// ResumeCommand builds a one-line resume command for display or clipboard, with
+// the prompt (if any) appended as a single-quoted argument. The prompt is
+// dropped for providers that do not accept one.
+func ResumeCommand(provider, sessionID, prompt string, fork bool, claudeFlags []string) string {
+	spec := BuildResumeSpec(provider, sessionID, fork, claudeFlags)
+	if prompt == "" || !spec.AcceptsPrompt {
+		return spec.Prefix
+	}
+	return spec.Prefix + " " + shellSingleQuote(prompt)
+}
+
+// shellSingleQuote wraps s in single quotes, safely escaping any embedded single
+// quotes for POSIX shells.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/core/session/resume_test.go
+++ b/internal/core/session/resume_test.go
@@ -1,0 +1,159 @@
+package session
+
+import "testing"
+
+func TestResumeBinary(t *testing.T) {
+	cases := map[string]string{
+		ProviderClaude:  "claude",
+		ProviderCodex:   "codex",
+		ProviderCopilot: "copilot",
+		"":              "claude",
+		"unknown":       "claude",
+	}
+	for provider, want := range cases {
+		if got := ResumeBinary(provider); got != want {
+			t.Errorf("ResumeBinary(%q) = %q, want %q", provider, got, want)
+		}
+	}
+}
+
+func TestBuildResumeSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    string
+		fork        bool
+		claudeFlags []string
+		wantPrefix  string
+		wantPrompt  bool
+		wantBinary  string
+	}{
+		{
+			name:       "claude default",
+			provider:   ProviderClaude,
+			wantPrefix: "claude --resume sess-1",
+			wantPrompt: true,
+			wantBinary: "claude",
+		},
+		{
+			name:        "claude with flags",
+			provider:    ProviderClaude,
+			claudeFlags: []string{"--dangerously-skip-permissions"},
+			wantPrefix:  "claude --dangerously-skip-permissions --resume sess-1",
+			wantPrompt:  true,
+			wantBinary:  "claude",
+		},
+		{
+			name:       "claude fork",
+			provider:   ProviderClaude,
+			fork:       true,
+			wantPrefix: "claude --resume sess-1 --fork-session",
+			wantPrompt: true,
+			wantBinary: "claude",
+		},
+		{
+			name:       "codex resume",
+			provider:   ProviderCodex,
+			wantPrefix: "codex resume sess-1",
+			wantPrompt: true,
+			wantBinary: "codex",
+		},
+		{
+			name:       "codex fork",
+			provider:   ProviderCodex,
+			fork:       true,
+			wantPrefix: "codex fork sess-1",
+			wantPrompt: true,
+			wantBinary: "codex",
+		},
+		{
+			name:       "copilot resume",
+			provider:   ProviderCopilot,
+			wantPrefix: "copilot --resume=sess-1",
+			wantPrompt: false,
+			wantBinary: "copilot",
+		},
+		{
+			name:        "codex ignores claude flags",
+			provider:    ProviderCodex,
+			claudeFlags: []string{"--dangerously-skip-permissions"},
+			wantPrefix:  "codex resume sess-1",
+			wantPrompt:  true,
+			wantBinary:  "codex",
+		},
+	}
+
+	// Codex stores sessions under a rollout filename; resume must use the
+	// trailing UUID. Verified separately below since the id differs.
+	t.Run("codex rollout id extracts uuid", func(t *testing.T) {
+		id := "rollout-2026-06-04T14-40-56-019e93f0-3efe-7742-9598-bb06b36fb25a"
+		spec := BuildResumeSpec(ProviderCodex, id, false, nil)
+		want := "codex resume 019e93f0-3efe-7742-9598-bb06b36fb25a"
+		if spec.Prefix != want {
+			t.Errorf("Prefix = %q, want %q", spec.Prefix, want)
+		}
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := BuildResumeSpec(tt.provider, "sess-1", tt.fork, tt.claudeFlags)
+			if spec.Prefix != tt.wantPrefix {
+				t.Errorf("Prefix = %q, want %q", spec.Prefix, tt.wantPrefix)
+			}
+			if spec.AcceptsPrompt != tt.wantPrompt {
+				t.Errorf("AcceptsPrompt = %v, want %v", spec.AcceptsPrompt, tt.wantPrompt)
+			}
+			if spec.Binary != tt.wantBinary {
+				t.Errorf("Binary = %q, want %q", spec.Binary, tt.wantBinary)
+			}
+		})
+	}
+}
+
+func TestResumeCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		prompt   string
+		fork     bool
+		want     string
+	}{
+		{
+			name:     "claude no prompt",
+			provider: ProviderClaude,
+			want:     "claude --resume sess-1",
+		},
+		{
+			name:     "claude with prompt",
+			provider: ProviderClaude,
+			prompt:   "pick up where we left off",
+			want:     "claude --resume sess-1 'pick up where we left off'",
+		},
+		{
+			name:     "codex with prompt",
+			provider: ProviderCodex,
+			prompt:   "keep going",
+			want:     "codex resume sess-1 'keep going'",
+		},
+		{
+			name:     "copilot drops prompt",
+			provider: ProviderCopilot,
+			prompt:   "keep going",
+			want:     "copilot --resume=sess-1",
+		},
+		{
+			name:     "prompt with single quote is escaped",
+			provider: ProviderClaude,
+			prompt:   "it's done",
+			want:     `claude --resume sess-1 'it'\''s done'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResumeCommand(tt.provider, "sess-1", tt.prompt, tt.fork, nil)
+			if got != tt.want {
+				t.Errorf("ResumeCommand = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/interface/cli/debug_prompt.go
+++ b/internal/interface/cli/debug_prompt.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/neilberkman/ccrider/internal/core/config"
 	"github.com/neilberkman/ccrider/internal/core/db"
+	coresession "github.com/neilberkman/ccrider/internal/core/session"
 	"github.com/spf13/cobra"
 )
 
@@ -87,7 +88,12 @@ func runDebugPrompt(cmd *cobra.Command, args []string) error {
 	fmt.Println(resumePrompt)
 	fmt.Println()
 	fmt.Println("=== COMMAND ===")
-	fmt.Printf("cd %s && claude --resume %s \"<prompt above>\"\n", projectPath, sessionID)
+	spec := coresession.BuildResumeSpec(session.Provider, sessionID, false, cfg.ClaudeFlags)
+	if spec.AcceptsPrompt {
+		fmt.Printf("cd %s && %s \"<prompt above>\"\n", projectPath, spec.Prefix)
+	} else {
+		fmt.Printf("cd %s && %s\n", projectPath, spec.Prefix)
+	}
 
 	return nil
 }

--- a/internal/interface/cli/list.go
+++ b/internal/interface/cli/list.go
@@ -35,7 +35,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().IntVar(&listLimit, "limit", 20, "Maximum number of sessions to display")
 	listCmd.Flags().StringVar(&listProject, "project", "", "Filter by project path")
-	listCmd.Flags().StringVar(&listProvider, "provider", "", "Filter by provider (claude, codex)")
+	listCmd.Flags().StringVar(&listProvider, "provider", "", "Filter by provider (claude, codex, copilot)")
 }
 
 func runList(cmd *cobra.Command, args []string) error {

--- a/internal/interface/cli/sync.go
+++ b/internal/interface/cli/sync.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/neilberkman/ccrider/internal/core/db"
 	"github.com/neilberkman/ccrider/internal/core/importer"
+	"github.com/neilberkman/ccrider/pkg/ccsessions"
 	"github.com/spf13/cobra"
 )
 
@@ -17,8 +17,10 @@ var (
 
 var syncCmd = &cobra.Command{
 	Use:   "sync [path]",
-	Short: "Import/sync Claude Code sessions",
-	Long: `Import sessions from ~/.claude/projects/ or a specified directory.
+	Short: "Import/sync coding agent sessions",
+	Long: `Import sessions from Claude Code (~/.claude/projects/), Codex CLI
+(~/.codex/sessions/), and GitHub Copilot CLI (~/.copilot/session-state/),
+or from a specified Claude Code directory.
 
 Performs incremental sync - only imports new or changed sessions.
 Use --force to re-import all sessions (fixes stale project_path values).`,
@@ -77,35 +79,44 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 	imp := importer.New(database)
 
-	for _, src := range importer.DefaultSources() {
-		// When user specified a custom path, only import Claude from that path
-		if len(args) > 0 && src.Provider != "claude" {
-			continue
-		}
-		importPath := src.Path
-		if len(args) > 0 {
-			importPath = sourcePath
-		}
+	// When the user passes an explicit path, import only Claude sessions from it;
+	// otherwise import every auto-discovered provider.
+	var sources []importer.Source
+	if len(args) > 0 {
+		sources = []importer.Source{{
+			Path:          sourcePath,
+			ParseFn:       ccsessions.ParseFile,
+			Provider:      "claude",
+			SkipSubagents: true,
+		}}
+	} else {
+		sources = importer.DefaultSources()
+	}
 
-		total, err := countJSONLFiles(importPath)
+	for _, src := range sources {
+		prepared, err := imp.PrepareSource(src)
 		if err != nil {
-			return fmt.Errorf("failed to count %s files: %w", src.Provider, err)
+			return fmt.Errorf("failed to prepare %s sessions: %w", src.Provider, err)
 		}
-		if total == 0 {
+		if prepared.Total == 0 {
 			continue
 		}
 
-		fmt.Printf("Syncing %s sessions from: %s\n", src.Provider, importPath)
-		progress := importer.NewProgressReporter(os.Stdout, total)
-		skipped, err := imp.ImportDirectory(importPath, progress, syncForce, src.SkipSubagents, src.ParseFn, src.Provider)
+		fmt.Printf("Syncing %s sessions from: %s\n", prepared.Provider, prepared.Path)
+		progress := importer.NewProgressReporter(os.Stdout, prepared.Total)
+		skipped, err := prepared.Run(progress, syncForce)
 		if err != nil {
 			return fmt.Errorf("%s import failed: %w", src.Provider, err)
 		}
 		progress.Finish()
 
 		if skipped > 0 && !syncForce {
-			skipRate := float64(skipped) / float64(total) * 100
-			fmt.Printf("\nSkipped %d/%d %s files (%.1f%% unchanged)\n", skipped, total, src.Provider, skipRate)
+			skipRate := float64(skipped) / float64(prepared.Total) * 100
+			unit := "files"
+			if src.EnumerateFn != nil {
+				unit = "sessions"
+			}
+			fmt.Printf("\nSkipped %d/%d %s %s (%.1f%% unchanged)\n", skipped, prepared.Total, src.Provider, unit, skipRate)
 		}
 	}
 
@@ -118,25 +129,4 @@ func getDefaultClaudeDir() string {
 		return "~/.claude/projects"
 	}
 	return filepath.Join(home, ".claude", "projects")
-}
-
-func countJSONLFiles(dirPath string) (int, error) {
-	count := 0
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && filepath.Ext(path) == ".jsonl" {
-			basename := filepath.Base(path)
-			if strings.Contains(basename, "Edit conflict") {
-				return nil
-			}
-			if strings.Contains(path, "/subagents/") || strings.HasPrefix(basename, "agent-") {
-				return nil
-			}
-			count++
-		}
-		return nil
-	})
-	return count, err
 }

--- a/internal/interface/cli/tui.go
+++ b/internal/interface/cli/tui.go
@@ -51,8 +51,9 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	// Check if user wants to launch a session
 	if m, ok := finalModel.(tui.Model); ok {
 		if m.LaunchSessionID != "" {
-			// Exec claude to replace this process
-			return execClaude(
+			// Exec the agent's resume command to replace this process
+			return execResume(
+				m.LaunchProvider,
 				m.LaunchSessionID,
 				m.LaunchProjectPath,
 				m.LaunchLastCwd,
@@ -64,6 +65,122 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// execResume dispatches to the right resume path for the session's provider.
+// Claude keeps its dedicated path (session-file recovery, prompt handling);
+// other agents (Codex, Copilot) use the generic execAgent path.
+func execResume(provider, sessionID, projectPath, lastCwd, updatedAt, summary string, fork bool) error {
+	switch provider {
+	case session.ProviderCodex, session.ProviderCopilot:
+		return execAgent(provider, sessionID, projectPath, lastCwd, updatedAt, summary, fork)
+	default:
+		return execClaude(sessionID, projectPath, lastCwd, updatedAt, summary, fork)
+	}
+}
+
+// execAgent resumes a non-Claude agent session (Codex, Copilot) by exec'ing the
+// provider's resume command, replacing the current process.
+func execAgent(provider, sessionID, projectPath, lastCwd, updatedAt, summary string, fork bool) error {
+	spec := session.BuildResumeSpec(provider, sessionID, fork, nil)
+	cmd := spec.Prefix
+
+	// Providers that accept an initial prompt (Codex) get the rendered resume
+	// prompt, passed via a temp file to avoid shell escaping issues.
+	if spec.AcceptsPrompt {
+		if cfg, err := config.Load(); err == nil {
+			if prompt := renderResumePrompt(cfg, projectPath, lastCwd, updatedAt); prompt != "" {
+				tmpfile, err := os.CreateTemp("", "ccrider-prompt-*.txt")
+				if err != nil {
+					return fmt.Errorf("failed to create temp file: %w", err)
+				}
+				defer func() { _ = os.Remove(tmpfile.Name()) }()
+				if _, err := tmpfile.Write([]byte(prompt)); err != nil {
+					_ = tmpfile.Close()
+					return fmt.Errorf("failed to write prompt: %w", err)
+				}
+				_ = tmpfile.Close()
+				cmd = fmt.Sprintf("%s \"$(cat %s)\"", spec.Prefix, tmpfile.Name())
+			}
+		}
+	}
+
+	// Resolve working directory (always projectPath, see session.ResolveWorkingDir)
+	workDir := session.ResolveWorkingDir(projectPath, lastCwd)
+
+	// Show what we're doing
+	fmt.Fprintf(os.Stderr, "[ccrider] cd %s && %s\n", workDir, cmd)
+
+	// Set terminal title before launching
+	updatedTime, _ := time.Parse("2006-01-02 15:04:05", updatedAt)
+	if updatedTime.IsZero() {
+		updatedTime, _ = time.Parse(time.RFC3339, updatedAt)
+	}
+	if !updatedTime.IsZero() && summary != "" {
+		titleTime := updatedTime.Format("01/02 15:04")
+		title := fmt.Sprintf("[resumed %s] %s", titleTime, summary)
+		fmt.Fprintf(os.Stderr, "\033]0;%s\007", title)
+	}
+
+	// Start spinner (agents can take a few seconds to start)
+	spinner := session.NewSpinner(fmt.Sprintf("Starting %s (this may take a few seconds)...", spec.Binary))
+	spinner.Start()
+	defer spinner.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	// Change to working directory
+	if workDir != "" {
+		if err := os.Chdir(workDir); err != nil {
+			return fmt.Errorf("failed to cd to %s: %w", workDir, err)
+		}
+	}
+
+	// Find shell
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/bash"
+	}
+
+	// Pre-flight check: verify the agent binary is runnable from this directory
+	if err := session.ValidateRunnable(provider, workDir); err != nil {
+		spinner.Stop()
+		return err
+	}
+
+	// Exec shell with the resume command (replaces current process)
+	return syscall.Exec(shell, []string{shell, "-l", "-c", cmd}, os.Environ())
+}
+
+// renderResumePrompt renders the configured resume prompt template for a session.
+// Returns an empty string if rendering yields nothing useful.
+func renderResumePrompt(cfg *config.Config, projectPath, lastCwd, updatedAt string) string {
+	updatedTime, _ := time.Parse("2006-01-02 15:04:05", updatedAt)
+	if updatedTime.IsZero() {
+		updatedTime, _ = time.Parse(time.RFC3339, updatedAt)
+	}
+
+	timeSince := "unknown"
+	if !updatedTime.IsZero() {
+		timeSince = humanize.Time(updatedTime)
+	}
+
+	sameDir := (lastCwd == projectPath)
+	templateData := map[string]interface{}{
+		"last_updated":        updatedAt,
+		"last_cwd":            lastCwd,
+		"time_since":          timeSince,
+		"project_path":        projectPath,
+		"same_directory":      sameDir,
+		"different_directory": !sameDir,
+	}
+
+	prompt, err := mustache.Render(cfg.ResumePromptTemplate, templateData)
+	if err != nil {
+		return fmt.Sprintf("Resuming session. You were last in: %s", lastCwd)
+	}
+	prompt = strings.ReplaceAll(prompt, "\n", " ")
+	prompt = strings.ReplaceAll(prompt, "\r", " ")
+	return prompt
 }
 
 func execClaude(sessionID, projectPath, lastCwd, updatedAt, summary string, fork bool) error {

--- a/internal/interface/tui/detail_view.go
+++ b/internal/interface/tui/detail_view.go
@@ -265,6 +265,7 @@ func (m Model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Resume session in Claude Code
 		if m.currentSession != nil {
 			return m, launchClaudeSession(
+				m.currentSession.Session.Provider,
 				m.currentSession.Session.ID,
 				m.currentSession.Session.Project,
 				m.currentSession.LastCwd,
@@ -279,6 +280,7 @@ func (m Model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Fork session (resume with new session ID)
 		if m.currentSession != nil {
 			return m, launchClaudeSession(
+				m.currentSession.Session.Provider,
 				m.currentSession.Session.ID,
 				m.currentSession.Session.Project,
 				m.currentSession.LastCwd,
@@ -293,6 +295,7 @@ func (m Model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Copy resume command to clipboard
 		if m.currentSession != nil {
 			return m, copyResumeCommand(
+				m.currentSession.Session.Provider,
 				m.currentSession.Session.ID,
 				m.currentSession.Session.Project,
 				m.currentSession.LastCwd,
@@ -305,6 +308,7 @@ func (m Model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.currentSession != nil {
 			m.err = nil // Clear any previous errors
 			return m, openInNewTerminal(
+				m.currentSession.Session.Provider,
 				m.currentSession.Session.ID,
 				m.currentSession.Session.Project,
 				m.currentSession.LastCwd,
@@ -554,6 +558,7 @@ type sessionLaunchedMsg struct {
 	success     bool
 	message     string
 	err         error
+	provider    string
 	sessionID   string
 	projectPath string
 	lastCwd     string
@@ -562,14 +567,16 @@ type sessionLaunchedMsg struct {
 	fork        bool
 }
 
-func launchClaudeSession(sessionID, projectPath, lastCwd, updatedAt, summary string, fork bool) tea.Cmd {
+func launchClaudeSession(provider, sessionID, projectPath, lastCwd, updatedAt, summary string, fork bool) tea.Cmd {
 	return func() tea.Msg {
 		// We need to exec() to replace the process, but bubbletea makes this tricky
 		// Instead, we'll return a special message telling the TUI to quit,
-		// then the CLI layer will exec claude
+		// then the CLI layer will exec the agent's resume command.
+		spec := session.BuildResumeSpec(provider, sessionID, fork, nil)
 		return sessionLaunchedMsg{
 			success:     true,
-			message:     fmt.Sprintf("cd %s && claude --resume %s", projectPath, sessionID),
+			message:     fmt.Sprintf("cd %s && %s", projectPath, spec.Prefix),
+			provider:    provider,
 			sessionID:   sessionID,
 			projectPath: projectPath,
 			lastCwd:     lastCwd,
@@ -580,21 +587,22 @@ func launchClaudeSession(sessionID, projectPath, lastCwd, updatedAt, summary str
 	}
 }
 
-func copyResumeCommand(sessionID, projectPath, lastCwd string) tea.Cmd {
-	return copyResumeCommandWithContext(sessionID, projectPath, lastCwd, false)
+func copyResumeCommand(provider, sessionID, projectPath, lastCwd string) tea.Cmd {
+	return copyResumeCommandWithContext(provider, sessionID, projectPath, lastCwd, false)
 }
 
-func copyResumeCommandWithContext(sessionID, projectPath, lastCwd string, fromFallbackView bool) tea.Cmd {
+func copyResumeCommandWithContext(provider, sessionID, projectPath, lastCwd string, fromFallbackView bool) tea.Cmd {
 	return func() tea.Msg {
 		// Resolve working directory (always projectPath, see session.ResolveWorkingDir)
 		workDir := session.ResolveWorkingDir(projectPath, lastCwd)
 
-		// Create a command that cd's to the working directory and runs claude
+		// Create a command that cd's to the working directory and runs the agent
+		resumeCmd := session.ResumeCommand(provider, sessionID, "", false, nil)
 		var cmd string
 		if workDir != "" {
-			cmd = fmt.Sprintf("cd %s && claude --resume %s", workDir, sessionID)
+			cmd = fmt.Sprintf("cd %s && %s", workDir, resumeCmd)
 		} else {
-			cmd = fmt.Sprintf("claude --resume %s", sessionID)
+			cmd = resumeCmd
 		}
 
 		// Use cross-platform clipboard library
@@ -621,17 +629,18 @@ func copyResumeCommandWithContext(sessionID, projectPath, lastCwd string, fromFa
 	}
 }
 
-func writeCommandToFile(sessionID, projectPath, lastCwd string) tea.Cmd {
+func writeCommandToFile(provider, sessionID, projectPath, lastCwd string) tea.Cmd {
 	return func() tea.Msg {
 		// Resolve working directory
 		workDir := session.ResolveWorkingDir(projectPath, lastCwd)
 
 		// Create command
+		resumeCmd := session.ResumeCommand(provider, sessionID, "", false, nil)
 		var cmd string
 		if workDir != "" {
-			cmd = fmt.Sprintf("cd %s && claude --resume %s", workDir, sessionID)
+			cmd = fmt.Sprintf("cd %s && %s", workDir, resumeCmd)
 		} else {
-			cmd = fmt.Sprintf("claude --resume %s", sessionID)
+			cmd = resumeCmd
 		}
 
 		// Write to file
@@ -657,6 +666,7 @@ type terminalSpawnedMsg struct {
 	success     bool
 	message     string
 	err         error
+	provider    string
 	sessionID   string
 	projectPath string
 	lastCwd     string
@@ -664,7 +674,7 @@ type terminalSpawnedMsg struct {
 	summary     string
 }
 
-func openInNewTerminal(sessionID, projectPath, lastCwd, updatedAt, summary string) tea.Cmd {
+func openInNewTerminal(provider, sessionID, projectPath, lastCwd, updatedAt, summary string) tea.Cmd {
 	return func() tea.Msg {
 		// Load config to get terminal command and resume prompt template
 		cfg, err := config.Load()
@@ -675,6 +685,9 @@ func openInNewTerminal(sessionID, projectPath, lastCwd, updatedAt, summary strin
 				err:     fmt.Errorf("config load: %w", err),
 			}
 		}
+
+		// Build the resume invocation for this provider.
+		spec := session.BuildResumeSpec(provider, sessionID, false, nil)
 
 		// Build template data for resume prompt
 		updatedTime, _ := time.Parse("2006-01-02 15:04:05", updatedAt)
@@ -690,35 +703,41 @@ func openInNewTerminal(sessionID, projectPath, lastCwd, updatedAt, summary strin
 		// Check if we're already in the right directory
 		sameDir := (lastCwd == projectPath)
 
-		templateData := map[string]interface{}{
-			"last_updated":        updatedAt,
-			"last_cwd":            lastCwd,
-			"time_since":          timeSince,
-			"project_path":        projectPath,
-			"same_directory":      sameDir,
-			"different_directory": !sameDir,
+		// Build the full command that will run in the new terminal. Providers
+		// that accept an initial prompt (Claude, Codex) get the rendered resume
+		// prompt; others (Copilot) resume without one.
+		shellCmd := spec.Prefix
+		if spec.AcceptsPrompt {
+			templateData := map[string]interface{}{
+				"last_updated":        updatedAt,
+				"last_cwd":            lastCwd,
+				"time_since":          timeSince,
+				"project_path":        projectPath,
+				"same_directory":      sameDir,
+				"different_directory": !sameDir,
+			}
+
+			// Render the resume prompt
+			resumePrompt, err := mustache.Render(cfg.ResumePromptTemplate, templateData)
+			if err != nil {
+				// Fall back to simple prompt if template fails
+				resumePrompt = fmt.Sprintf("Resuming session. You were last in: %s", lastCwd)
+			}
+
+			// Replace newlines with spaces for shell command
+			resumePrompt = strings.ReplaceAll(resumePrompt, "\n", " ")
+			resumePrompt = strings.ReplaceAll(resumePrompt, "\r", " ")
+
+			// Build via ResumeCommand so the prompt is safely shell-quoted
+			// (a prompt or cwd containing a single quote must not break the command).
+			shellCmd = session.ResumeCommand(provider, sessionID, resumePrompt, false, nil)
 		}
-
-		// Render the resume prompt
-		resumePrompt, err := mustache.Render(cfg.ResumePromptTemplate, templateData)
-		if err != nil {
-			// Fall back to simple prompt if template fails
-			resumePrompt = fmt.Sprintf("Resuming session. You were last in: %s", lastCwd)
-		}
-
-		// Replace newlines with spaces for shell command
-		resumePrompt = strings.ReplaceAll(resumePrompt, "\n", " ")
-		resumePrompt = strings.ReplaceAll(resumePrompt, "\r", " ")
-
-		// Build the full command that will run in the new terminal
-		// Use shell with the prompt as an argument to claude
-		shellCmd := fmt.Sprintf("claude --resume %s '%s'", sessionID, resumePrompt)
 
 		// Resolve working directory (always projectPath, see session.ResolveWorkingDir)
 		workDir := session.ResolveWorkingDir(projectPath, lastCwd)
 
-		// Pre-flight check: verify claude is runnable from this directory
-		if err := session.ValidateClaudeRunnable(workDir); err != nil {
+		// Pre-flight check: verify the agent binary is runnable from this directory
+		if err := session.ValidateRunnable(provider, workDir); err != nil {
 			return terminalSpawnedMsg{
 				success: false,
 				err:     err,
@@ -735,13 +754,14 @@ func openInNewTerminal(sessionID, projectPath, lastCwd, updatedAt, summary strin
 		spawnCfg := terminal.SpawnConfig{
 			WorkingDir: workDir,
 			Command:    shellCmd,
-			Message:    "Starting Claude Code (this may take a few seconds)...",
+			Message:    "Starting " + session.ResumeBinary(provider) + " (this may take a few seconds)...",
 		}
 
 		if err := spawner.Spawn(spawnCfg); err != nil {
 			return terminalSpawnedMsg{
 				success:     false,
 				err:         err,
+				provider:    provider,
 				sessionID:   sessionID,
 				projectPath: projectPath,
 				lastCwd:     lastCwd,

--- a/internal/interface/tui/messages.go
+++ b/internal/interface/tui/messages.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -226,17 +225,21 @@ type syncProgressMsg struct {
 // StartSyncWithProgress initiates a sync and returns a command that listens for progress
 func startSyncWithProgress(database *db.DB, filterByProject bool, projectPath string) tea.Cmd {
 	return func() tea.Msg {
-		sources := importer.DefaultSources()
+		imp := importer.New(database)
 
-		// Count total files across all source directories
+		// Resolve each source (count work + import action) via core. Sources that
+		// fail to prepare (e.g. an unreadable Copilot store) are surfaced as a
+		// warning rather than silently dropped.
+		var prepared []importer.PreparedSource
 		var total int
-		for _, src := range sources {
-			_ = filepath.Walk(src.Path, func(path string, info os.FileInfo, err error) error {
-				if err == nil && !info.IsDir() && filepath.Ext(path) == ".jsonl" {
-					total++
-				}
-				return nil
-			})
+		for _, src := range importer.DefaultSources() {
+			p, err := imp.PrepareSource(src)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", src.Provider, err)
+				continue
+			}
+			prepared = append(prepared, p)
+			total += p.Total
 		}
 
 		progressCh := make(chan syncProgressMsg, 100)
@@ -247,16 +250,15 @@ func startSyncWithProgress(database *db.DB, filterByProject bool, projectPath st
 		}
 
 		go func() {
-			imp := importer.New(database)
 			progress := &channelProgressReporter{
 				total:   total,
 				current: 0,
 				ch:      progressCh,
 			}
 
-			for _, src := range sources {
-				if _, err := imp.ImportDirectory(src.Path, progress, false, src.SkipSubagents, src.ParseFn, src.Provider); err != nil {
-					fmt.Fprintf(os.Stderr, "WARN: %s sync failed: %v\n", src.Provider, err)
+			for _, p := range prepared {
+				if _, err := p.Run(progress, false); err != nil {
+					fmt.Fprintf(os.Stderr, "WARN: %s sync failed: %v\n", p.Provider, err)
 				}
 			}
 

--- a/internal/interface/tui/messages.go
+++ b/internal/interface/tui/messages.go
@@ -26,6 +26,7 @@ type sessionDetailLoadedMsg struct {
 }
 
 type sessionLaunchInfoMsg struct {
+	provider    string
 	sessionID   string
 	projectPath string
 	lastCwd     string
@@ -163,6 +164,7 @@ func loadSessionForLaunch(database *db.DB, sessionID string) tea.Cmd {
 		}
 
 		return sessionLaunchInfoMsg{
+			provider:    session.Provider,
 			sessionID:   session.SessionID,
 			projectPath: session.ProjectPath,
 			lastCwd:     lastCwd,

--- a/internal/interface/tui/model.go
+++ b/internal/interface/tui/model.go
@@ -57,6 +57,7 @@ type Model struct {
 	matchOccurrences        []matchOccurrenceInfo // line number + occurrence index for each match (for scrolling and highlighting)
 
 	// Launch state (for exec after quit)
+	LaunchProvider    string
 	LaunchSessionID   string
 	LaunchProjectPath string
 	LaunchLastCwd     string
@@ -65,6 +66,7 @@ type Model struct {
 	LaunchFork        bool
 
 	// Terminal fallback state (when can't spawn terminal)
+	fallbackProvider    string
 	fallbackSessionID   string
 	fallbackProjectPath string
 	fallbackLastCwd     string
@@ -340,6 +342,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionLaunchInfoMsg:
 		// Got session info for quick launch (from list view 'o' key)
 		return m, openInNewTerminal(
+			msg.provider,
 			msg.sessionID,
 			msg.projectPath,
 			msg.lastCwd,
@@ -357,6 +360,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionLaunchedMsg:
 		if msg.success {
 			// Store launch info for CLI to exec after quit
+			m.LaunchProvider = msg.provider
 			m.LaunchSessionID = msg.sessionID
 			m.LaunchProjectPath = msg.projectPath
 			m.LaunchLastCwd = msg.lastCwd
@@ -387,6 +391,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.err != nil && strings.Contains(msg.err.Error(), "could not detect supported terminal") {
 				// Switch to fallback view with options
 				m.mode = terminalFallbackView
+				m.fallbackProvider = msg.provider
 				m.fallbackSessionID = msg.sessionID
 				m.fallbackProjectPath = msg.projectPath
 				m.fallbackLastCwd = msg.lastCwd

--- a/internal/interface/tui/terminal_fallback_view.go
+++ b/internal/interface/tui/terminal_fallback_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/neilberkman/ccrider/internal/core/session"
 )
 
 func (m Model) updateTerminalFallback(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -11,6 +12,7 @@ func (m Model) updateTerminalFallback(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		// Resume in current terminal
 		return m, launchClaudeSession(
+			m.fallbackProvider,
 			m.fallbackSessionID,
 			m.fallbackProjectPath,
 			m.fallbackLastCwd,
@@ -22,6 +24,7 @@ func (m Model) updateTerminalFallback(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "c":
 		// Copy command to clipboard - with fallback message
 		return m, copyResumeCommandWithContext(
+			m.fallbackProvider,
 			m.fallbackSessionID,
 			m.fallbackProjectPath,
 			m.fallbackLastCwd,
@@ -31,6 +34,7 @@ func (m Model) updateTerminalFallback(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "w":
 		// Write command to file
 		return m, writeCommandToFile(
+			m.fallbackProvider,
 			m.fallbackSessionID,
 			m.fallbackProjectPath,
 			m.fallbackLastCwd,
@@ -56,11 +60,12 @@ func (m Model) viewTerminalFallback() string {
 		workDir = m.fallbackLastCwd
 	}
 
+	resumeCmd := session.ResumeCommand(m.fallbackProvider, m.fallbackSessionID, "", false, nil)
 	var cmd string
 	if workDir != "" {
-		cmd = fmt.Sprintf("cd %s && claude --resume %s", workDir, m.fallbackSessionID)
+		cmd = fmt.Sprintf("cd %s && %s", workDir, resumeCmd)
 	} else {
-		cmd = fmt.Sprintf("claude --resume %s", m.fallbackSessionID)
+		cmd = resumeCmd
 	}
 
 	return fmt.Sprintf(`

--- a/pkg/copilotsessions/parser.go
+++ b/pkg/copilotsessions/parser.go
@@ -1,0 +1,262 @@
+// Package copilotsessions parses GitHub Copilot CLI sessions.
+//
+// The Copilot CLI keeps a per-session event log at
+// ~/.copilot/session-state/<uuid>/events.jsonl, plus a small workspace.yaml
+// with session metadata (name, cwd). It also maintains a derived SQLite index
+// at ~/.copilot/session-store.db, but that index collapses each multi-step
+// assistant turn into a single, condensed `assistant_response` row — it loses a
+// meaningful fraction of the assistant's text. We therefore parse events.jsonl,
+// which is the full transcript and the same per-session-file shape as Claude
+// Code and Codex, and use workspace.yaml only for the session summary/cwd.
+//
+// ParseAll walks the session-state directory and returns one
+// ccsessions.ParsedSession per session that has a conversation.
+package copilotsessions
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/neilberkman/ccrider/pkg/ccsessions"
+)
+
+// DefaultStateDir returns the path to the Copilot CLI per-session state
+// directory, or "" if the home directory cannot be determined.
+func DefaultStateDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".copilot", "session-state")
+}
+
+// rawEvent is one line of events.jsonl. Each event carries a globally-unique id
+// (used directly as the message UUID), its parent's id, a timestamp, and a
+// type-specific data payload.
+type rawEvent struct {
+	Type      string          `json:"type"`
+	ID        string          `json:"id"`
+	ParentID  string          `json:"parentId"`
+	Timestamp string          `json:"timestamp"`
+	Data      json.RawMessage `json:"data"`
+}
+
+type sessionStartData struct {
+	Context struct {
+		CWD string `json:"cwd"`
+	} `json:"context"`
+}
+
+type messageData struct {
+	Content string `json:"content"`
+}
+
+// parseTime parses Copilot event timestamps (RFC3339, "...Z").
+func parseTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// ParseAll walks stateDir and parses each session's events.jsonl. Sessions with
+// no events.jsonl (or no conversational messages) are skipped. A missing
+// stateDir is not an error — it just yields no sessions.
+func ParseAll(stateDir string) ([]*ccsessions.ParsedSession, error) {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read copilot state dir: %w", err)
+	}
+
+	var sessions []*ccsessions.ParsedSession
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionID := entry.Name()
+		sessionDir := filepath.Join(stateDir, sessionID)
+		eventsPath := filepath.Join(sessionDir, "events.jsonl")
+
+		info, err := os.Stat(eventsPath)
+		if err != nil {
+			// No event log for this session (never had a conversation) — skip.
+			continue
+		}
+
+		session, err := parseSession(sessionDir, sessionID, eventsPath, info)
+		if err != nil {
+			// Skip an unreadable/corrupt session rather than failing the whole sync.
+			continue
+		}
+		if session != nil {
+			sessions = append(sessions, session)
+		}
+	}
+
+	return sessions, nil
+}
+
+// parseSession parses one session's events.jsonl into a ParsedSession, or nil if
+// it has no conversational messages.
+func parseSession(sessionDir, sessionID, eventsPath string, info os.FileInfo) (*ccsessions.ParsedSession, error) {
+	file, err := os.Open(eventsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	// workspace.yaml carries the human-friendly session name (used as summary)
+	// and the cwd; fall back to the cwd from the session.start event.
+	wsName, wsCWD := readWorkspace(filepath.Join(sessionDir, "workspace.yaml"))
+	cwd := wsCWD
+
+	reader := bufio.NewReaderSize(file, 1024*1024)
+	dec := json.NewDecoder(reader)
+
+	var messages []ccsessions.ParsedMessage
+	sequence := 0
+
+	for {
+		var ev rawEvent
+		if err := dec.Decode(&ev); err != nil {
+			if err == io.EOF {
+				break
+			}
+			// Malformed tail (e.g. a partially-written final line on a live
+			// session): keep what we parsed so far.
+			break
+		}
+
+		switch ev.Type {
+		case "session.start", "session.resume":
+			// The event stream is authoritative for cwd; the workspace.yaml value
+			// is only a fallback for sessions whose start event lacks one.
+			var d sessionStartData
+			if json.Unmarshal(ev.Data, &d) == nil && d.Context.CWD != "" {
+				cwd = d.Context.CWD
+			}
+
+		case "user.message":
+			var d messageData
+			if json.Unmarshal(ev.Data, &d) != nil || strings.TrimSpace(d.Content) == "" {
+				continue
+			}
+			sequence++
+			messages = append(messages, ccsessions.ParsedMessage{
+				UUID:        ev.ID,
+				ParentUUID:  ev.ParentID,
+				Type:        "user",
+				Sender:      "human",
+				TextContent: d.Content,
+				Timestamp:   parseTime(ev.Timestamp),
+				Sequence:    sequence,
+				CWD:         cwd,
+			})
+
+		case "assistant.message":
+			var d messageData
+			if json.Unmarshal(ev.Data, &d) != nil || strings.TrimSpace(d.Content) == "" {
+				continue
+			}
+			sequence++
+			messages = append(messages, ccsessions.ParsedMessage{
+				UUID:        ev.ID,
+				ParentUUID:  ev.ParentID,
+				Type:        "assistant",
+				Sender:      "assistant",
+				TextContent: d.Content,
+				Timestamp:   parseTime(ev.Timestamp),
+				Sequence:    sequence,
+				CWD:         cwd,
+			})
+		}
+	}
+
+	if len(messages) == 0 {
+		return nil, nil
+	}
+
+	summary := wsName
+	if summary == "" {
+		// Fall back to the first user message, matching the other parsers.
+		for _, m := range messages {
+			if m.Sender == "human" && m.TextContent != "" {
+				runes := []rune(m.TextContent)
+				if len(runes) > 120 {
+					summary = string(runes[:120])
+				} else {
+					summary = m.TextContent
+				}
+				break
+			}
+		}
+	}
+
+	return &ccsessions.ParsedSession{
+		SessionID: sessionID,
+		Summary:   summary,
+		// Synthetic path so the importer derives session_id == the Copilot UUID
+		// from the file basename (every events.jsonl is literally "events.jsonl",
+		// so the parent dir name is the only per-session identifier).
+		FilePath:  filepath.Join(sessionDir, sessionID+".copilot"),
+		FileSize:  info.Size(),
+		FileMtime: info.ModTime(),
+		Messages:  messages,
+	}, nil
+}
+
+// readWorkspace extracts the session name and cwd from a Copilot workspace.yaml.
+// The file is flat (top-level "key: value" scalars), so a minimal line parser
+// avoids pulling in a YAML dependency.
+func readWorkspace(path string) (name, cwd string) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", ""
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Only consider top-level keys (no leading whitespace).
+		if len(line) == 0 || line[0] == ' ' || line[0] == '\t' || line[0] == '#' {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "name":
+			name = unquoteYAML(strings.TrimSpace(value))
+		case "cwd":
+			cwd = unquoteYAML(strings.TrimSpace(value))
+		}
+	}
+	return name, cwd
+}
+
+// unquoteYAML strips a single pair of surrounding quotes from a scalar value.
+func unquoteYAML(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/pkg/copilotsessions/parser_test.go
+++ b/pkg/copilotsessions/parser_test.go
@@ -1,0 +1,175 @@
+package copilotsessions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSession creates a session-state/<id>/ directory with the given
+// events.jsonl lines and (optionally) a workspace.yaml name.
+func writeSession(t *testing.T, stateDir, sessionID, workspaceName string, eventLines ...string) {
+	t.Helper()
+	dir := filepath.Join(stateDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if len(eventLines) > 0 {
+		if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(strings.Join(eventLines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatalf("write events: %v", err)
+		}
+	}
+	if workspaceName != "" {
+		ws := "id: " + sessionID + "\nname: " + workspaceName + "\ncwd: /from/workspace\n"
+		if err := os.WriteFile(filepath.Join(dir, "workspace.yaml"), []byte(ws), 0o644); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+	}
+}
+
+const (
+	evStart = `{"type":"session.start","id":"start-1","timestamp":"2026-06-03T12:13:05.376Z","data":{"context":{"cwd":"/Users/dmd/project"}}}`
+	evUser0 = `{"type":"user.message","id":"u0","parentId":"start-1","timestamp":"2026-06-03T12:13:11.138Z","data":{"content":"make it build"}}`
+	evAsst0 = `{"type":"assistant.message","id":"a0","parentId":"u0","timestamp":"2026-06-03T12:14:16.948Z","data":{"content":"Done, build is green."}}`
+	// assistant.message with empty content (tool-only step) must be dropped.
+	evAsstEmpty = `{"type":"assistant.message","id":"a-empty","parentId":"u0","timestamp":"2026-06-03T12:14:17.000Z","data":{"content":"","toolRequests":[{"name":"shell"}]}}`
+	evUser1     = `{"type":"user.message","id":"u1","parentId":"a0","timestamp":"2026-06-03T12:15:00.000Z","data":{"content":"thanks"}}`
+	// non-conversational events that must be ignored.
+	evSystem = `{"type":"system.message","id":"sys-1","timestamp":"2026-06-03T12:13:05.500Z","data":{"infoType":"folder_trust","message":"trusted"}}`
+)
+
+func TestParseAll(t *testing.T) {
+	stateDir := t.TempDir()
+	writeSession(t, stateDir, "sess-a", "Fix the build",
+		evStart, evSystem, evUser0, evAsst0, evAsstEmpty, evUser1)
+
+	sessions, err := ParseAll(stateDir)
+	if err != nil {
+		t.Fatalf("ParseAll: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+
+	s := sessions[0]
+	if s.SessionID != "sess-a" {
+		t.Errorf("SessionID = %q, want sess-a", s.SessionID)
+	}
+	if s.Summary != "Fix the build" {
+		t.Errorf("Summary = %q, want workspace name", s.Summary)
+	}
+	// Importer derives the session key from the file basename; it must round-trip
+	// to the Copilot UUID (the session-state directory name).
+	base := filepath.Base(s.FilePath)
+	if got := base[:len(base)-len(filepath.Ext(base))]; got != "sess-a" {
+		t.Errorf("FilePath basename = %q, want session id sess-a", got)
+	}
+
+	// 3 conversational messages: user, assistant(content), user.
+	// The empty assistant.message and the system.message are dropped.
+	if len(s.Messages) != 3 {
+		t.Fatalf("got %d messages, want 3", len(s.Messages))
+	}
+	want := []struct{ uuid, sender, text string }{
+		{"u0", "human", "make it build"},
+		{"a0", "assistant", "Done, build is green."},
+		{"u1", "human", "thanks"},
+	}
+	for i, w := range want {
+		m := s.Messages[i]
+		if m.UUID != w.uuid || m.Sender != w.sender || m.TextContent != w.text {
+			t.Errorf("message[%d] = (%q,%q,%q), want (%q,%q,%q)",
+				i, m.UUID, m.Sender, m.TextContent, w.uuid, w.sender, w.text)
+		}
+		if m.CWD != "/Users/dmd/project" {
+			t.Errorf("message[%d] CWD = %q, want cwd from session.start", i, m.CWD)
+		}
+	}
+	if s.Messages[1].ParentUUID != "u0" {
+		t.Errorf("assistant ParentUUID = %q, want u0", s.Messages[1].ParentUUID)
+	}
+}
+
+func TestParseAllSummaryFallback(t *testing.T) {
+	stateDir := t.TempDir()
+	// No workspace.yaml name -> summary falls back to first user message.
+	writeSession(t, stateDir, "sess-b", "", evStart, evUser0, evAsst0)
+
+	sessions, err := ParseAll(stateDir)
+	if err != nil {
+		t.Fatalf("ParseAll: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if sessions[0].Summary != "make it build" {
+		t.Errorf("Summary fallback = %q, want first user message", sessions[0].Summary)
+	}
+}
+
+func TestParseAllCwdFromWorkspaceWhenNoSessionStart(t *testing.T) {
+	stateDir := t.TempDir()
+	// No session.start event -> cwd comes from workspace.yaml.
+	writeSession(t, stateDir, "sess-c", "Named", evUser0, evAsst0)
+
+	sessions, err := ParseAll(stateDir)
+	if err != nil {
+		t.Fatalf("ParseAll: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if sessions[0].Messages[0].CWD != "/from/workspace" {
+		t.Errorf("CWD = %q, want /from/workspace", sessions[0].Messages[0].CWD)
+	}
+}
+
+func TestParseAllSkipsSessionsWithoutConversation(t *testing.T) {
+	stateDir := t.TempDir()
+	// Has a conversation -> kept.
+	writeSession(t, stateDir, "real", "Real", evStart, evUser0, evAsst0)
+	// Directory with no events.jsonl -> skipped.
+	if err := os.MkdirAll(filepath.Join(stateDir, "no-events"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// events.jsonl with only non-conversational events -> skipped.
+	writeSession(t, stateDir, "only-system", "Sys", evStart, evSystem)
+
+	sessions, err := ParseAll(stateDir)
+	if err != nil {
+		t.Fatalf("ParseAll: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1 (only the real conversation)", len(sessions))
+	}
+	if sessions[0].SessionID != "real" {
+		t.Errorf("kept %q, want real", sessions[0].SessionID)
+	}
+}
+
+func TestParseAllMissingStateDir(t *testing.T) {
+	sessions, err := ParseAll(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("ParseAll on missing dir should not error, got %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("got %d sessions, want 0", len(sessions))
+	}
+}
+
+func TestReadWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workspace.yaml")
+	content := "id: abc\nname: My Session: With Colon\ncwd: /tmp/x\nuser_named: false\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	name, cwd := readWorkspace(path)
+	if name != "My Session: With Colon" {
+		t.Errorf("name = %q, want full value past first colon", name)
+	}
+	if cwd != "/tmp/x" {
+		t.Errorf("cwd = %q, want /tmp/x", cwd)
+	}
+}


### PR DESCRIPTION
Adds GitHub Copilot CLI as a third session provider, alongside a fix that makes session resume provider-aware. Two commits, reviewable independently.

## Commit 1 — provider-aware resume
ccrider hardcoded `claude --resume` for every provider, so resuming a Codex session generated a `claude` command (and hit Claude's session-recovery mode, since the Claude session file never exists for a Codex session).

- New `internal/core/session/resume.go`: `ResumeBinary`, `BuildResumeSpec`, `ResumeCommand`, provider constants. Single source of truth for each agent's resume syntax (`claude --resume <id>`, `codex resume <id>`, `copilot --resume=<id>`).
- `ValidateRunnable` checks the correct binary; recovery mode stays Claude-only.
- Provider is threaded through the TUI launch/copy/spawn/fallback paths and the CLI exec path. For Codex, the bare session UUID is extracted from the stored rollout filename.
- Resume prompts spawned into a new terminal are shell-quoted via `ResumeCommand`, so a prompt or cwd containing a single quote can't break/inject the command.

Claude behavior is unchanged.

## Commit 2 — GitHub Copilot CLI support
Copilot CLI stores sessions in a single SQLite database (`~/.copilot/session-store.db`) rather than per-session JSONL files.

- New `pkg/copilotsessions` parser reads the `sessions`/`turns` tables read-only (safe while Copilot is running) and yields one human/assistant message per turn.
- Importer `Source` gains an `EnumerateFn`; new `ImportEnumerated` imports DB-backed providers with a synthetic content hash for incremental skip detection. `DefaultSources` adds Copilot when the db exists; CLI and TUI sync handle enumerated sources.
- Message UUIDs are content-addressed by `(session_id, turn_index, role)` so a backfilled turn can't shift later UUIDs; import relies on `ON CONFLICT(uuid)` dedup rather than append-only ordering. Zero-turn sessions are skipped.
- Copilot sessions are tagged `[copilot]`, filterable via `--provider`/MCP `provider`, searchable via FTS, and resumable via `copilot --resume=<id>`.

## Testing
- `go build ./...`, `go test ./...`, and `golangci-lint v2.5.0` all clean.
- New unit tests: provider-aware resume commands; Copilot parser (turns→messages, empty-response handling, summary fallback, zero-turn skip, UUID stability across backfill).
- Verified end-to-end against a real `~/.copilot/session-store.db`: sync imports Copilot sessions alongside Claude/Codex, list/view/search/resume work, and incremental re-sync skips unchanged sessions.