### PR TITLE
Shell-quote session IDs and working dirs in resume commands

### DIFF
--- a/internal/core/session/resume.go
+++ b/internal/core/session/resume.go
@@ -59,6 +59,9 @@ type ResumeSpec struct {
 // BuildResumeSpec returns provider-specific resume invocation details.
 // claudeFlags are only applied for the Claude CLI.
 func BuildResumeSpec(provider, sessionID string, fork bool, claudeFlags []string) ResumeSpec {
+	// Session IDs come from the database and are normally UUID/rollout-shaped,
+	// but shell-quote them anyway so an unexpected value can never break out of
+	// the command (defense-in-depth, since this string is run by a shell).
 	switch provider {
 	case ProviderCodex:
 		// codex resume <id> [prompt]; forking uses `codex fork <id> [prompt]`.
@@ -68,14 +71,14 @@ func BuildResumeSpec(provider, sessionID string, fork bool, claudeFlags []string
 		}
 		return ResumeSpec{
 			Binary:        "codex",
-			Prefix:        fmt.Sprintf("codex %s %s", verb, codexResumeID(sessionID)),
+			Prefix:        fmt.Sprintf("codex %s %s", verb, ShellQuote(codexResumeID(sessionID))),
 			AcceptsPrompt: true,
 		}
 	case ProviderCopilot:
 		// copilot --resume=<id>; interactive resume has no positional prompt.
 		return ResumeSpec{
 			Binary:        "copilot",
-			Prefix:        fmt.Sprintf("copilot --resume=%s", sessionID),
+			Prefix:        fmt.Sprintf("copilot --resume=%s", ShellQuote(sessionID)),
 			AcceptsPrompt: false,
 		}
 	default:
@@ -83,7 +86,7 @@ func BuildResumeSpec(provider, sessionID string, fork bool, claudeFlags []string
 		if len(claudeFlags) > 0 {
 			flags = " " + strings.Join(claudeFlags, " ")
 		}
-		prefix := fmt.Sprintf("claude%s --resume %s", flags, sessionID)
+		prefix := fmt.Sprintf("claude%s --resume %s", flags, ShellQuote(sessionID))
 		if fork {
 			prefix += " --fork-session"
 		}
@@ -103,11 +106,11 @@ func ResumeCommand(provider, sessionID, prompt string, fork bool, claudeFlags []
 	if prompt == "" || !spec.AcceptsPrompt {
 		return spec.Prefix
 	}
-	return spec.Prefix + " " + shellSingleQuote(prompt)
+	return spec.Prefix + " " + ShellQuote(prompt)
 }
 
-// shellSingleQuote wraps s in single quotes, safely escaping any embedded single
-// quotes for POSIX shells.
-func shellSingleQuote(s string) string {
+// ShellQuote wraps s in single quotes, safely escaping any embedded single
+// quotes, so it can be interpolated into a POSIX shell command as one argument.
+func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/core/session/resume_test.go
+++ b/internal/core/session/resume_test.go
@@ -1,6 +1,9 @@
 package session
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestResumeBinary(t *testing.T) {
 	cases := map[string]string{
@@ -13,6 +16,21 @@ func TestResumeBinary(t *testing.T) {
 	for provider, want := range cases {
 		if got := ResumeBinary(provider); got != want {
 			t.Errorf("ResumeBinary(%q) = %q, want %q", provider, got, want)
+		}
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"abc":             "'abc'",
+		"":                "''",
+		"a b":             "'a b'",
+		"it's":            `'it'\''s'`,
+		"x'; rm -rf /; '": `'x'\''; rm -rf /; '\'''`,
+	}
+	for in, want := range cases {
+		if got := ShellQuote(in); got != want {
+			t.Errorf("ShellQuote(%q) = %q, want %q", in, got, want)
 		}
 	}
 }
@@ -30,7 +48,7 @@ func TestBuildResumeSpec(t *testing.T) {
 		{
 			name:       "claude default",
 			provider:   ProviderClaude,
-			wantPrefix: "claude --resume sess-1",
+			wantPrefix: "claude --resume 'sess-1'",
 			wantPrompt: true,
 			wantBinary: "claude",
 		},
@@ -38,7 +56,7 @@ func TestBuildResumeSpec(t *testing.T) {
 			name:        "claude with flags",
 			provider:    ProviderClaude,
 			claudeFlags: []string{"--dangerously-skip-permissions"},
-			wantPrefix:  "claude --dangerously-skip-permissions --resume sess-1",
+			wantPrefix:  "claude --dangerously-skip-permissions --resume 'sess-1'",
 			wantPrompt:  true,
 			wantBinary:  "claude",
 		},
@@ -46,14 +64,14 @@ func TestBuildResumeSpec(t *testing.T) {
 			name:       "claude fork",
 			provider:   ProviderClaude,
 			fork:       true,
-			wantPrefix: "claude --resume sess-1 --fork-session",
+			wantPrefix: "claude --resume 'sess-1' --fork-session",
 			wantPrompt: true,
 			wantBinary: "claude",
 		},
 		{
 			name:       "codex resume",
 			provider:   ProviderCodex,
-			wantPrefix: "codex resume sess-1",
+			wantPrefix: "codex resume 'sess-1'",
 			wantPrompt: true,
 			wantBinary: "codex",
 		},
@@ -61,14 +79,14 @@ func TestBuildResumeSpec(t *testing.T) {
 			name:       "codex fork",
 			provider:   ProviderCodex,
 			fork:       true,
-			wantPrefix: "codex fork sess-1",
+			wantPrefix: "codex fork 'sess-1'",
 			wantPrompt: true,
 			wantBinary: "codex",
 		},
 		{
 			name:       "copilot resume",
 			provider:   ProviderCopilot,
-			wantPrefix: "copilot --resume=sess-1",
+			wantPrefix: "copilot --resume='sess-1'",
 			wantPrompt: false,
 			wantBinary: "copilot",
 		},
@@ -76,20 +94,32 @@ func TestBuildResumeSpec(t *testing.T) {
 			name:        "codex ignores claude flags",
 			provider:    ProviderCodex,
 			claudeFlags: []string{"--dangerously-skip-permissions"},
-			wantPrefix:  "codex resume sess-1",
+			wantPrefix:  "codex resume 'sess-1'",
 			wantPrompt:  true,
 			wantBinary:  "codex",
 		},
 	}
 
 	// Codex stores sessions under a rollout filename; resume must use the
-	// trailing UUID. Verified separately below since the id differs.
+	// trailing UUID (and quote it). Verified separately since the id differs.
 	t.Run("codex rollout id extracts uuid", func(t *testing.T) {
 		id := "rollout-2026-06-04T14-40-56-019e93f0-3efe-7742-9598-bb06b36fb25a"
 		spec := BuildResumeSpec(ProviderCodex, id, false, nil)
-		want := "codex resume 019e93f0-3efe-7742-9598-bb06b36fb25a"
+		want := "codex resume '019e93f0-3efe-7742-9598-bb06b36fb25a'"
 		if spec.Prefix != want {
 			t.Errorf("Prefix = %q, want %q", spec.Prefix, want)
+		}
+	})
+
+	// A session id containing shell metacharacters must be neutralized by
+	// quoting so it cannot break out of the command.
+	t.Run("malicious id is quoted", func(t *testing.T) {
+		id := "x'; rm -rf /; '"
+		for _, provider := range []string{ProviderClaude, ProviderCodex, ProviderCopilot} {
+			spec := BuildResumeSpec(provider, id, false, nil)
+			if !strings.Contains(spec.Prefix, ShellQuote(id)) {
+				t.Errorf("%s prefix = %q, want it to contain the quoted id %q", provider, spec.Prefix, ShellQuote(id))
+			}
 		}
 	})
 
@@ -120,31 +150,31 @@ func TestResumeCommand(t *testing.T) {
 		{
 			name:     "claude no prompt",
 			provider: ProviderClaude,
-			want:     "claude --resume sess-1",
+			want:     "claude --resume 'sess-1'",
 		},
 		{
 			name:     "claude with prompt",
 			provider: ProviderClaude,
 			prompt:   "pick up where we left off",
-			want:     "claude --resume sess-1 'pick up where we left off'",
+			want:     "claude --resume 'sess-1' 'pick up where we left off'",
 		},
 		{
 			name:     "codex with prompt",
 			provider: ProviderCodex,
 			prompt:   "keep going",
-			want:     "codex resume sess-1 'keep going'",
+			want:     "codex resume 'sess-1' 'keep going'",
 		},
 		{
 			name:     "copilot drops prompt",
 			provider: ProviderCopilot,
 			prompt:   "keep going",
-			want:     "copilot --resume=sess-1",
+			want:     "copilot --resume='sess-1'",
 		},
 		{
 			name:     "prompt with single quote is escaped",
 			provider: ProviderClaude,
 			prompt:   "it's done",
-			want:     `claude --resume sess-1 'it'\''s done'`,
+			want:     `claude --resume 'sess-1' 'it'\''s done'`,
 		},
 	}
 

--- a/internal/core/terminal/spawn.go
+++ b/internal/core/terminal/spawn.go
@@ -83,7 +83,7 @@ func (s *Spawner) Spawn(cfg SpawnConfig) error {
 func (s *Spawner) spawnGhostty(cfg SpawnConfig) error {
 	// Ghostty on macOS: Use clipboard + paste approach
 	// Save current clipboard, use it, then restore
-	fullCmd := fmt.Sprintf("cd %s", cfg.WorkingDir)
+	fullCmd := fmt.Sprintf("cd %s", shellQuoteDir(cfg.WorkingDir))
 	if cfg.Message != "" {
 		fullCmd += fmt.Sprintf(" && echo '%s'", cfg.Message)
 	}
@@ -132,7 +132,7 @@ end tell
 
 func (s *Spawner) spawnITerm(cfg SpawnConfig) error {
 	// iTerm2: Use AppleScript
-	cmdStr := fmt.Sprintf("cd %s", cfg.WorkingDir)
+	cmdStr := fmt.Sprintf("cd %s", shellQuoteDir(cfg.WorkingDir))
 	if cfg.Message != "" {
 		// Escape single quotes in message for shell
 		safeMsg := strings.ReplaceAll(cfg.Message, "'", "'\\''")
@@ -156,7 +156,7 @@ end tell
 func (s *Spawner) spawnTerminalApp(cfg SpawnConfig) error {
 	// Terminal.app: Use AppleScript to open new window
 	// Build command string (will be executed by shell in Terminal)
-	cmdStr := fmt.Sprintf("cd %s", cfg.WorkingDir)
+	cmdStr := fmt.Sprintf("cd %s", shellQuoteDir(cfg.WorkingDir))
 	if cfg.Message != "" {
 		// Escape single quotes in message for shell
 		safeMsg := strings.ReplaceAll(cfg.Message, "'", "'\\''")
@@ -228,11 +228,19 @@ func (s *Spawner) spawnKonsole(cfg SpawnConfig) error {
 
 func (s *Spawner) spawnXTerm(cfg SpawnConfig) error {
 	// XTerm - basic but universally available
-	fullCmd := fmt.Sprintf("cd %s && %s", cfg.WorkingDir, cfg.Command)
+	fullCmd := fmt.Sprintf("cd %s && %s", shellQuoteDir(cfg.WorkingDir), cfg.Command)
 	cmd := exec.Command("xterm",
 		"-e", "bash", "-l", "-c", fullCmd,
 	)
 	return cmd.Start()
+}
+
+// shellQuoteDir single-quotes a working directory so it can be interpolated
+// into a `cd` command run by a shell (working dirs routinely contain spaces,
+// e.g. cloud-storage paths). Kept local so this low-level package stays
+// dependency-free.
+func shellQuoteDir(dir string) string {
+	return "'" + strings.ReplaceAll(dir, "'", `'\''`) + "'"
 }
 
 // appleScriptEscape escapes a string for use in AppleScript do script command

--- a/internal/interface/cli/debug_prompt.go
+++ b/internal/interface/cli/debug_prompt.go
@@ -90,9 +90,9 @@ func runDebugPrompt(cmd *cobra.Command, args []string) error {
 	fmt.Println("=== COMMAND ===")
 	spec := coresession.BuildResumeSpec(session.Provider, sessionID, false, cfg.ClaudeFlags)
 	if spec.AcceptsPrompt {
-		fmt.Printf("cd %s && %s \"<prompt above>\"\n", projectPath, spec.Prefix)
+		fmt.Printf("cd %s && %s \"<prompt above>\"\n", coresession.ShellQuote(projectPath), spec.Prefix)
 	} else {
-		fmt.Printf("cd %s && %s\n", projectPath, spec.Prefix)
+		fmt.Printf("cd %s && %s\n", coresession.ShellQuote(projectPath), spec.Prefix)
 	}
 
 	return nil

--- a/internal/interface/cli/tui.go
+++ b/internal/interface/cli/tui.go
@@ -109,7 +109,7 @@ func execAgent(provider, sessionID, projectPath, lastCwd, updatedAt, summary str
 	workDir := session.ResolveWorkingDir(projectPath, lastCwd)
 
 	// Show what we're doing
-	fmt.Fprintf(os.Stderr, "[ccrider] cd %s && %s\n", workDir, cmd)
+	fmt.Fprintf(os.Stderr, "[ccrider] cd %s && %s\n", session.ShellQuote(workDir), cmd)
 
 	// Set terminal title before launching
 	updatedTime, _ := time.Parse("2006-01-02 15:04:05", updatedAt)
@@ -246,16 +246,16 @@ func execClaude(sessionID, projectPath, lastCwd, updatedAt, summary string, fork
 		flags = " " + strings.Join(cfg.ClaudeFlags, " ")
 	}
 	if fork {
-		cmd = fmt.Sprintf("claude%s --resume %s --fork-session \"$(cat %s)\"", flags, sessionID, tmpfile.Name())
+		cmd = fmt.Sprintf("claude%s --resume %s --fork-session \"$(cat %s)\"", flags, session.ShellQuote(sessionID), tmpfile.Name())
 	} else {
-		cmd = fmt.Sprintf("claude%s --resume %s \"$(cat %s)\"", flags, sessionID, tmpfile.Name())
+		cmd = fmt.Sprintf("claude%s --resume %s \"$(cat %s)\"", flags, session.ShellQuote(sessionID), tmpfile.Name())
 	}
 
 	// Resolve working directory (always projectPath, see session.ResolveWorkingDir)
 	workDir := session.ResolveWorkingDir(projectPath, lastCwd)
 
 	// Show what we're doing
-	fmt.Fprintf(os.Stderr, "[ccrider] cd %s && %s\n", workDir, cmd)
+	fmt.Fprintf(os.Stderr, "[ccrider] cd %s && %s\n", session.ShellQuote(workDir), cmd)
 
 	// Set terminal title before launching
 	if !updatedTime.IsZero() && summary != "" {

--- a/internal/interface/tui/detail_view.go
+++ b/internal/interface/tui/detail_view.go
@@ -575,7 +575,7 @@ func launchClaudeSession(provider, sessionID, projectPath, lastCwd, updatedAt, s
 		spec := session.BuildResumeSpec(provider, sessionID, fork, nil)
 		return sessionLaunchedMsg{
 			success:     true,
-			message:     fmt.Sprintf("cd %s && %s", projectPath, spec.Prefix),
+			message:     fmt.Sprintf("cd %s && %s", session.ShellQuote(projectPath), spec.Prefix),
 			provider:    provider,
 			sessionID:   sessionID,
 			projectPath: projectPath,
@@ -600,7 +600,7 @@ func copyResumeCommandWithContext(provider, sessionID, projectPath, lastCwd stri
 		resumeCmd := session.ResumeCommand(provider, sessionID, "", false, nil)
 		var cmd string
 		if workDir != "" {
-			cmd = fmt.Sprintf("cd %s && %s", workDir, resumeCmd)
+			cmd = fmt.Sprintf("cd %s && %s", session.ShellQuote(workDir), resumeCmd)
 		} else {
 			cmd = resumeCmd
 		}
@@ -638,7 +638,7 @@ func writeCommandToFile(provider, sessionID, projectPath, lastCwd string) tea.Cm
 		resumeCmd := session.ResumeCommand(provider, sessionID, "", false, nil)
 		var cmd string
 		if workDir != "" {
-			cmd = fmt.Sprintf("cd %s && %s", workDir, resumeCmd)
+			cmd = fmt.Sprintf("cd %s && %s", session.ShellQuote(workDir), resumeCmd)
 		} else {
 			cmd = resumeCmd
 		}

--- a/internal/interface/tui/terminal_fallback_view.go
+++ b/internal/interface/tui/terminal_fallback_view.go
@@ -63,7 +63,7 @@ func (m Model) viewTerminalFallback() string {
 	resumeCmd := session.ResumeCommand(m.fallbackProvider, m.fallbackSessionID, "", false, nil)
 	var cmd string
 	if workDir != "" {
-		cmd = fmt.Sprintf("cd %s && %s", workDir, resumeCmd)
+		cmd = fmt.Sprintf("cd %s && %s", session.ShellQuote(workDir), resumeCmd)
 	} else {
 		cmd = resumeCmd
 	}


### PR DESCRIPTION
Follow-up to #14 (the UUID-validation + workDir-quoting pass you asked for).

The resume prompt was already quoted via `ShellQuote`, but two things were still interpolated into shell command strings raw:

- the **session ID** — `claude --resume <id>`, `codex resume <id>`, `copilot --resume=<id>`
- the **working dir** — `cd <workDir> && …`

Session IDs come from the DB (UUID/rollout-shaped) and working dirs routinely contain spaces (cloud-storage paths like `~/Library/CloudStorage/Dropbox-…`), so this could break the command or, with a crafted id, inject into it.

## Changes
- Export `session.ShellQuote` and quote the session ID inside `BuildResumeSpec` for all three providers, so every consumer (TUI resume/copy/spawn/fallback, CLI exec, debug-prompt) gets it for free.
- Quote the working dir at every `cd %s` site: `detail_view.go` (copy + write-to-file + launch message), `terminal_fallback_view.go`, `debug_prompt.go`, the CLI exec echo in `tui.go`, and the terminal spawner `terminal/spawn.go` (Ghostty/iTerm/Terminal.app/xterm all run `cd <dir>` through a shell — this also fixes spawning into a directory with a space, which was already broken). `terminal/` keeps a tiny local quoter so it stays dependency-free.

## Note on approach
You suggested validating session IDs against a UUID-ish pattern. I went with quoting instead — it closes the injection class for *any* input (not just non-UUID ones), reuses the single `ShellQuote` helper already used for prompts, and avoids a reject/error path in display/clipboard code. Quoting a normal UUID just yields `'019e…'`, which is harmless when pasted.

## Testing
- New tests: `ShellQuote` (incl. embedded quotes / metacharacters) and a malicious-id case asserting `BuildResumeSpec` neutralizes `x'; rm -rf /; '` for every provider. Existing resume-command tests updated for the quoted form.
- `go build`, `go test ./...`, `golangci-lint run` clean.