### PR TITLE
Skip malformed lines in the Copilot events.jsonl parser

### DIFF
--- a/pkg/copilotsessions/parser.go
+++ b/pkg/copilotsessions/parser.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,65 +123,68 @@ func parseSession(sessionDir, sessionID, eventsPath string, info os.FileInfo) (*
 	wsName, wsCWD := readWorkspace(filepath.Join(sessionDir, "workspace.yaml"))
 	cwd := wsCWD
 
+	// Read events line by line and skip any malformed line, so one corrupt
+	// line (e.g. a partially-flushed write on a live session) doesn't drop the
+	// rest of the transcript — matching the Claude/Codex parsers. ReadBytes
+	// grows to fit arbitrarily long event lines.
 	reader := bufio.NewReaderSize(file, 1024*1024)
-	dec := json.NewDecoder(reader)
 
 	var messages []ccsessions.ParsedMessage
 	sequence := 0
 
 	for {
-		var ev rawEvent
-		if err := dec.Decode(&ev); err != nil {
-			if err == io.EOF {
-				break
+		line, readErr := reader.ReadBytes('\n')
+
+		if len(line) > 0 {
+			var ev rawEvent
+			if json.Unmarshal(line, &ev) == nil {
+				switch ev.Type {
+				case "session.start", "session.resume":
+					// The event stream is authoritative for cwd; the
+					// workspace.yaml value is only a fallback for sessions
+					// whose start event lacks one.
+					var d sessionStartData
+					if json.Unmarshal(ev.Data, &d) == nil && d.Context.CWD != "" {
+						cwd = d.Context.CWD
+					}
+
+				case "user.message":
+					var d messageData
+					if json.Unmarshal(ev.Data, &d) == nil && strings.TrimSpace(d.Content) != "" {
+						sequence++
+						messages = append(messages, ccsessions.ParsedMessage{
+							UUID:        ev.ID,
+							ParentUUID:  ev.ParentID,
+							Type:        "user",
+							Sender:      "human",
+							TextContent: d.Content,
+							Timestamp:   parseTime(ev.Timestamp),
+							Sequence:    sequence,
+							CWD:         cwd,
+						})
+					}
+
+				case "assistant.message":
+					var d messageData
+					if json.Unmarshal(ev.Data, &d) == nil && strings.TrimSpace(d.Content) != "" {
+						sequence++
+						messages = append(messages, ccsessions.ParsedMessage{
+							UUID:        ev.ID,
+							ParentUUID:  ev.ParentID,
+							Type:        "assistant",
+							Sender:      "assistant",
+							TextContent: d.Content,
+							Timestamp:   parseTime(ev.Timestamp),
+							Sequence:    sequence,
+							CWD:         cwd,
+						})
+					}
+				}
 			}
-			// Malformed tail (e.g. a partially-written final line on a live
-			// session): keep what we parsed so far.
-			break
 		}
 
-		switch ev.Type {
-		case "session.start", "session.resume":
-			// The event stream is authoritative for cwd; the workspace.yaml value
-			// is only a fallback for sessions whose start event lacks one.
-			var d sessionStartData
-			if json.Unmarshal(ev.Data, &d) == nil && d.Context.CWD != "" {
-				cwd = d.Context.CWD
-			}
-
-		case "user.message":
-			var d messageData
-			if json.Unmarshal(ev.Data, &d) != nil || strings.TrimSpace(d.Content) == "" {
-				continue
-			}
-			sequence++
-			messages = append(messages, ccsessions.ParsedMessage{
-				UUID:        ev.ID,
-				ParentUUID:  ev.ParentID,
-				Type:        "user",
-				Sender:      "human",
-				TextContent: d.Content,
-				Timestamp:   parseTime(ev.Timestamp),
-				Sequence:    sequence,
-				CWD:         cwd,
-			})
-
-		case "assistant.message":
-			var d messageData
-			if json.Unmarshal(ev.Data, &d) != nil || strings.TrimSpace(d.Content) == "" {
-				continue
-			}
-			sequence++
-			messages = append(messages, ccsessions.ParsedMessage{
-				UUID:        ev.ID,
-				ParentUUID:  ev.ParentID,
-				Type:        "assistant",
-				Sender:      "assistant",
-				TextContent: d.Content,
-				Timestamp:   parseTime(ev.Timestamp),
-				Sequence:    sequence,
-				CWD:         cwd,
-			})
+		if readErr != nil {
+			break
 		}
 	}
 

--- a/pkg/copilotsessions/parser_test.go
+++ b/pkg/copilotsessions/parser_test.go
@@ -173,3 +173,39 @@ func TestReadWorkspace(t *testing.T) {
 		t.Errorf("cwd = %q, want /tmp/x", cwd)
 	}
 }
+
+// TestParseAllSkipsMalformedLine ensures a corrupt line in the middle of
+// events.jsonl doesn't drop the rest of the session (matches the Claude parser).
+func TestParseAllSkipsMalformedLine(t *testing.T) {
+	stateDir := t.TempDir()
+	writeSession(t, stateDir, "sess-x", "Resilient",
+		evStart,
+		evUser0,
+		`{ this is not valid json at all `, // corrupt line mid-stream
+		evAsst0,
+		``, // blank line
+		evUser1,
+	)
+
+	sessions, err := ParseAll(stateDir)
+	if err != nil {
+		t.Fatalf("ParseAll: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	// All three valid messages survive; the corrupt and blank lines are skipped.
+	got := make([]string, 0, len(sessions[0].Messages))
+	for _, m := range sessions[0].Messages {
+		got = append(got, m.TextContent)
+	}
+	want := []string{"make it build", "Done, build is green.", "thanks"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d messages %v, want %v", len(got), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("message[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #14.

`parseSession` used a streaming `json.Decoder` and `break`s on the first decode error. A single corrupt line — e.g. a partially-flushed write while a Copilot session is live, or any truncation — therefore drops every event after it, losing the rest of the transcript.

Switched to reading `events.jsonl` line by line (`bufio.Reader.ReadBytes('\n')`, which grows to fit arbitrarily long event lines) and skipping any line that fails to `json.Unmarshal`, continuing past it. This matches how the Claude and Codex parsers already handle bad lines.

Regression test `TestParseAllSkipsMalformedLine`: a session whose events.jsonl has a corrupt line (and a blank line) between valid events still yields all the valid messages.

`go build`, `go test ./...`, `golangci-lint run` clean.