### PR TITLE
Derive enumerated skip-hash from message content instead of mtime

### DIFF
--- a/internal/core/importer/importer.go
+++ b/internal/core/importer/importer.go
@@ -448,12 +448,19 @@ func (i *Importer) ImportEnumerated(sessions []*ccsessions.ParsedSession, progre
 	return skipped, nil
 }
 
-// enumeratedSessionHash produces a change-detection hash for a database-backed
-// session. It changes whenever the session's last-updated time or message count
-// changes, which is sufficient to detect new turns on an existing session.
+// enumeratedSessionHash produces a change-detection hash for an enumerated
+// session from its message content rather than the file mtime. Hashing each
+// message's UUID and full text detects any add, remove, reorder, or in-place
+// edit (including a same-length rewrite), so it doesn't depend on the source
+// bumping a timestamp and won't churn if an unrelated mtime changes.
 func enumeratedSessionHash(sessionID string, session *ccsessions.ParsedSession) string {
 	h := blake3.New()
-	_, _ = fmt.Fprintf(h, "%s|%d|%d", sessionID, session.FileMtime.UnixNano(), len(session.Messages))
+	_, _ = fmt.Fprintf(h, "%s|%d", sessionID, len(session.Messages))
+	for _, m := range session.Messages {
+		// Length-frame each field so message/text boundaries are unambiguous.
+		_, _ = fmt.Fprintf(h, "|%s:%d:", m.UUID, len(m.TextContent))
+		_, _ = io.WriteString(h, m.TextContent)
+	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/internal/core/importer/importer_test.go
+++ b/internal/core/importer/importer_test.go
@@ -378,3 +378,37 @@ func TestImportEnumeratedRefreshesEditedText(t *testing.T) {
 		t.Errorf("FTS still matches stale text 'aardvark' after edit")
 	}
 }
+
+func TestEnumeratedSessionHash(t *testing.T) {
+	mk := func(mtime time.Time, msgs ...ccsessions.ParsedMessage) *ccsessions.ParsedSession {
+		return &ccsessions.ParsedSession{SessionID: "s", FilePath: "/x/s.copilot", FileMtime: mtime, Messages: msgs}
+	}
+	m := func(uuid, text string) ccsessions.ParsedMessage {
+		return ccsessions.ParsedMessage{UUID: uuid, TextContent: text}
+	}
+	t0 := time.Unix(1000, 0)
+	t1 := time.Unix(2000, 0)
+
+	base := enumeratedSessionHash("s", mk(t0, m("a", "hello"), m("b", "world")))
+
+	// Same content, different mtime -> same hash (mtime is no longer an input).
+	if h := enumeratedSessionHash("s", mk(t1, m("a", "hello"), m("b", "world"))); h != base {
+		t.Errorf("hash changed on mtime-only change: %s vs %s", h, base)
+	}
+	// Edited text with a different length -> different hash.
+	if h := enumeratedSessionHash("s", mk(t0, m("a", "hello!"), m("b", "world"))); h == base {
+		t.Error("hash unchanged after a text edit")
+	}
+	// Same-length in-place edit ("world" -> "WORLD") -> different hash.
+	if h := enumeratedSessionHash("s", mk(t0, m("a", "hello"), m("b", "WORLD"))); h == base {
+		t.Error("hash unchanged after a same-length text edit")
+	}
+	// Added message -> different hash.
+	if h := enumeratedSessionHash("s", mk(t0, m("a", "hello"), m("b", "world"), m("c", "!"))); h == base {
+		t.Error("hash unchanged after adding a message")
+	}
+	// Changed UUID -> different hash.
+	if h := enumeratedSessionHash("s", mk(t0, m("a", "hello"), m("z", "world"))); h == base {
+		t.Error("hash unchanged after a uuid change")
+	}
+}


### PR DESCRIPTION
Follow-up to #14.

`enumeratedSessionHash` (the incremental skip check for enumerated providers like Copilot) hashed `sessionID | events.jsonl mtime | message count`. Per your suggestion, it now hashes each message's UUID + text length (plus the count) instead of the mtime.

Benefits:
- Detects added, removed, reordered, and length-changing messages directly from content.
- No longer churns (forces a re-import) when only the file mtime changes.
- Doesn't depend on the source bumping a timestamp to notice a change.

(A same-length in-place edit still slips through the skip check — but if a session is re-imported for any other reason, the widened `ON CONFLICT` from #14 refreshes the text correctly.)

Note: because the hash format changes, the next sync re-imports existing Copilot sessions once (idempotent), then settles.

New test `TestEnumeratedSessionHash` covers mtime-invariance plus edit/add/uuid-change detection. `go build`, `go test ./...`, `golangci-lint run` clean.