### PR TITLE
fix: type j/k into in-session search instead of scrolling viewport

### DIFF
--- a/internal/interface/tui/detail_view.go
+++ b/internal/interface/tui/detail_view.go
@@ -201,9 +201,11 @@ func (m Model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 
-			case "j", "down", "k", "up":
-				// Manual scrolling
-				if msg.String() == "j" || msg.String() == "down" {
+			case "down", "up":
+				// Manual scrolling with arrow keys only. j/k are intentionally
+				// NOT bound here: while typing a query they are ordinary search
+				// characters and must fall through to the text input below.
+				if msg.String() == "down" {
 					m.viewport.ScrollDown(1)
 				} else {
 					m.viewport.ScrollUp(1)

--- a/internal/interface/tui/insession_search_key_test.go
+++ b/internal/interface/tui/insession_search_key_test.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Regression for the "k gets blocked" bug: while typing a query into the
+// in-session search box (search mode active, NOT navigation mode), the letters
+// "j" and "k" must be inserted into the text input, not hijacked as vim-style
+// viewport scroll commands. Any query containing j or k was silently losing
+// those characters.
+func TestInSessionSearchAcceptsJAndK(t *testing.T) {
+	ti := textinput.New()
+	ti.Focus()
+	m := Model{
+		mode:                detailView,
+		inSessionSearchMode: true, // typing in the search box
+		inSessionSearch:     ti,
+		width:               80,
+		currentSession: &sessionDetail{
+			Messages: []messageItem{{Type: "user", Content: "kotopia jest"}},
+		},
+	}
+
+	for _, r := range "kj" {
+		model, _ := m.updateDetail(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = model.(Model)
+	}
+
+	if got := m.inSessionSearch.Value(); got != "kj" {
+		t.Errorf("in-session search value = %q, want %q (j/k must type, not scroll)", got, "kj")
+	}
+}


### PR DESCRIPTION
## Problem

In the detail (session) view's in-session search, typing a query that contains the letters **`j`** or **`k`** silently drops those characters. Typing `kotopia` yields `otopia`; `jest` yields `est`. This makes many in-session searches impossible to enter, since `j`/`k` are extremely common letters.

## Root cause

In `internal/interface/tui/detail_view.go`, the in-session search handler has two sub-modes:

- **navigation mode** (after pressing <kbd>Enter</kbd>) — `n`/`p` cycle matches, `j`/`k` scroll. Correct.
- **typing mode** (right after pressing `/` or <kbd>Ctrl+F</kbd>) — keystrokes should go to the search text input.

But the typing-mode handler intercepted `j`/`k` (and `up`/`down`) for viewport scrolling **before** they reached the text input:

```go
case "j", "down", "k", "up":
    // Manual scrolling
    if msg.String() == "j" || msg.String() == "down" {
        m.viewport.ScrollDown(1)
    } else {
        m.viewport.ScrollUp(1)
    }
    return m, nil

default:
    // Everything else goes to text input   <- where j/k should have gone
    m.inSessionSearch, cmd = m.inSessionSearch.Update(msg)
```

So `j`/`k` scrolled the viewport instead of being inserted into the query.

## Fix

Bind only the **arrow keys** (`up`/`down`) to scroll-while-searching, and let `j`/`k` fall through to the text input as ordinary characters. Navigation mode is untouched — `j`/`k` still scroll there, which is correct because you're cycling matches, not typing.

## Test

Adds a regression test (`TestInSessionSearchAcceptsJAndK`) that types `"kj"` into the in-session search box and asserts both characters land in the input. It fails before the change (captured value is `""`) and passes after.

## Reproduction

1. `ccrider tui`
2. Open any session
3. Press `/`
4. Type a word containing `j` or `k` (e.g. `kotopia`)
5. Before: the `k`/`j` are eaten and scroll the view. After: they type normally.