### PR TITLE
Fix toolbar offsets

### DIFF
--- a/internal/interface/tui/detail_view.go
+++ b/internal/interface/tui/detail_view.go
@@ -16,7 +16,7 @@ import (
 )
 
 func createViewport(detail sessionDetail, width, height int) viewport.Model {
-	vp := viewport.New(width, height-8)
+	vp := viewport.New(width, height-4)
 	result := renderConversation(detail, "", nil, -1, width, nil)
 	vp.SetContent(result.content)
 	return vp

--- a/internal/interface/tui/detail_view.go
+++ b/internal/interface/tui/detail_view.go
@@ -16,7 +16,7 @@ import (
 )
 
 func createViewport(detail sessionDetail, width, height int) viewport.Model {
-	vp := viewport.New(width, height-4)
+	vp := viewport.New(width, height-3)
 	result := renderConversation(detail, "", nil, -1, width, nil)
 	vp.SetContent(result.content)
 	return vp

--- a/internal/interface/tui/list_view.go
+++ b/internal/interface/tui/list_view.go
@@ -3,11 +3,11 @@ package tui
 import (
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 )
 
@@ -213,11 +213,9 @@ func (m Model) viewList() string {
 		return "No sessions found. Press 's' to sync.\n\n" + helpText
 	}
 
-	// Render list and help on same line with no gap
-	listView := m.list.View()
-	// Strip trailing newlines from list view to eliminate gap
-	listView = strings.TrimRight(listView, "\n")
-	return listView + "\n" + helpText
+	// JoinVertical preserves the list's Height()-padded output and places
+	// helpText on the very last line, regardless of trailing padding.
+	return lipgloss.JoinVertical(lipgloss.Left, m.list.View(), helpText)
 }
 
 func formatTime(t string) string {

--- a/internal/interface/tui/model.go
+++ b/internal/interface/tui/model.go
@@ -199,13 +199,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Update list dimensions if it's been created
 		if m.list.Paginator.TotalPages > 0 {
-			m.list.SetSize(m.width, m.height-4)
+			m.list.SetSize(m.width, m.height-1)
 		}
 
 		// Update viewport dimensions if it's been created
 		if m.viewport.Height > 0 {
 			m.viewport.Width = m.width
-			m.viewport.Height = m.height - 8
+			m.viewport.Height = m.height - 4
 		}
 
 		return m, nil

--- a/internal/interface/tui/model.go
+++ b/internal/interface/tui/model.go
@@ -205,7 +205,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Update viewport dimensions if it's been created
 		if m.viewport.Height > 0 {
 			m.viewport.Width = m.width
-			m.viewport.Height = m.height - 4
+			m.viewport.Height = m.height - 3
 		}
 
 		return m, nil


### PR DESCRIPTION
The keyboard shortcut toolbar on the pager view after selecting a session has an offset due to some incorrect hardcoded height values.

Before

<img width="800" height="875" alt="out2" src="https://github.com/user-attachments/assets/9d06bd8b-3e50-448e-9640-83554114b946" />

After

<img width="800" height="875" alt="out" src="https://github.com/user-attachments/assets/91660e48-a7d3-49d1-bb98-a901f63ced49" />
