### PR TITLE
fix: let Amp sync scale to large accounts

### DIFF
--- a/internal/core/importer/amp.go
+++ b/internal/core/importer/amp.go
@@ -50,7 +50,13 @@ func runAmpWithWaitDelay(ctx context.Context, waitDelay time.Duration, args ...s
 		return output, nil
 	}
 	if ctx.Err() == nil && errors.Is(runErr, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
-		return output, nil
+		// WaitDelay can close stdout while a forked child is still writing.
+		// Every Amp command consumed here returns one JSON value, so only accept
+		// output that was complete before the pipe was closed.
+		if json.Valid(output) {
+			return output, nil
+		}
+		return nil, fmt.Errorf("run amp command: %w: incomplete JSON output", runErr)
 	}
 	message := strings.TrimSpace(stderr.String())
 	if ctxErr := ctx.Err(); ctxErr != nil {

--- a/internal/core/importer/amp.go
+++ b/internal/core/importer/amp.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -36,12 +37,19 @@ func newAmpClient() *ampClient {
 }
 
 func runAmp(ctx context.Context, args ...string) ([]byte, error) {
+	return runAmpWithWaitDelay(ctx, ampProcessWaitDelay, args...)
+}
+
+func runAmpWithWaitDelay(ctx context.Context, waitDelay time.Duration, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "amp", args...)
-	cmd.WaitDelay = ampProcessWaitDelay
+	cmd.WaitDelay = waitDelay
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	output, runErr := cmd.Output()
 	if runErr == nil {
+		return output, nil
+	}
+	if ctx.Err() == nil && errors.Is(runErr, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
 		return output, nil
 	}
 	message := strings.TrimSpace(stderr.String())

--- a/internal/core/importer/amp.go
+++ b/internal/core/importer/amp.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	ampProvider        = "amp"
-	ampDefaultPageSize = 100
-	ampCommandTimeout  = 30 * time.Second
+	ampProvider         = "amp"
+	ampDefaultPageSize  = 100
+	ampCommandTimeout   = 30 * time.Second
+	ampProcessWaitDelay = 2 * time.Second
 )
 
 type ampRunFunc func(context.Context, ...string) ([]byte, error)
@@ -36,6 +37,7 @@ func newAmpClient() *ampClient {
 
 func runAmp(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "amp", args...)
+	cmd.WaitDelay = ampProcessWaitDelay
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	output, runErr := cmd.Output()

--- a/internal/core/importer/amp_test.go
+++ b/internal/core/importer/amp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -258,6 +259,23 @@ func TestRunAmpUsesOutputAfterCleanExitWaitDelay(t *testing.T) {
 	}
 	if elapsed := time.Since(started); elapsed > 2*time.Second {
 		t.Fatalf("clean process with inherited pipe returned after %s, want bounded wait", elapsed)
+	}
+}
+
+func TestRunAmpRejectsIncompleteOutputAfterCleanExitWaitDelay(t *testing.T) {
+	binDir := t.TempDir()
+	ampPath := filepath.Join(binDir, "amp")
+	if err := os.WriteFile(ampPath, []byte("#!/bin/sh\n(sleep 1; printf ']') &\nprintf '['\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	output, err := runAmpWithWaitDelay(context.Background(), 20*time.Millisecond, "threads", "list")
+	if !errors.Is(err, exec.ErrWaitDelay) || !strings.Contains(err.Error(), "incomplete JSON output") {
+		t.Fatalf("runAmpWithWaitDelay() error = %v, want incomplete WaitDelay output error", err)
+	}
+	if output != nil {
+		t.Fatalf("output = %q, want rejected incomplete output", output)
 	}
 }
 

--- a/internal/core/importer/amp_test.go
+++ b/internal/core/importer/amp_test.go
@@ -239,3 +239,40 @@ func TestRunAmpPreservesDeadline(t *testing.T) {
 		t.Fatalf("runAmp() error = %v, want deadline", err)
 	}
 }
+
+func TestRunAmpUsesOutputAfterCleanExitWaitDelay(t *testing.T) {
+	binDir := t.TempDir()
+	ampPath := filepath.Join(binDir, "amp")
+	if err := os.WriteFile(ampPath, []byte("#!/bin/sh\n(sleep 5) &\nprintf '[]'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	started := time.Now()
+	output, err := runAmpWithWaitDelay(context.Background(), 20*time.Millisecond, "threads", "list")
+	if err != nil {
+		t.Fatalf("runAmpWithWaitDelay() error = %v, want clean output", err)
+	}
+	if string(output) != "[]" {
+		t.Fatalf("output = %q, want []", output)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("clean process with inherited pipe returned after %s, want bounded wait", elapsed)
+	}
+}
+
+func TestRunAmpCallerDeadlineTakesPrecedenceOverCleanExitWaitDelay(t *testing.T) {
+	binDir := t.TempDir()
+	ampPath := filepath.Join(binDir, "amp")
+	if err := os.WriteFile(ampPath, []byte("#!/bin/sh\n(sleep 5) &\nprintf '[]'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := runAmpWithWaitDelay(ctx, time.Second, "threads", "list")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runAmpWithWaitDelay() error = %v, want caller deadline", err)
+	}
+}

--- a/internal/core/importer/amp_test.go
+++ b/internal/core/importer/amp_test.go
@@ -191,15 +191,21 @@ func TestAmpClientAddsPerCommandDeadline(t *testing.T) {
 	client := &ampClient{
 		pageSize: 100,
 		timeout:  time.Second,
-		run: func(ctx context.Context, _ ...string) ([]byte, error) {
+		run: func(ctx context.Context, args ...string) ([]byte, error) {
 			deadline, ok := ctx.Deadline()
 			if !ok || time.Until(deadline) > time.Second {
 				t.Fatalf("command deadline = %v, ok = %v", deadline, ok)
+			}
+			if len(args) >= 2 && args[1] == "export" {
+				return []byte(`{"id":"T-one","messages":[]}`), nil
 			}
 			return []byte("[]"), nil
 		},
 	}
 	if _, err := client.listThreads(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.exportThread(context.Background(), "T-one"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/core/importer/importer.go
+++ b/internal/core/importer/importer.go
@@ -25,6 +25,7 @@ type ImportFailure struct {
 type ImportResult struct {
 	Imported int
 	Skipped  int
+	Deferred int
 	Failures []ImportFailure
 }
 
@@ -537,6 +538,14 @@ func (i *Importer) ImportEnumerated(ctx context.Context, sessions []*ccsessions.
 // export on subsequent syncs.
 func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fetch func(context.Context, RemoteSessionRef) (*ccsessions.ParsedSession, error), progress ProgressCallback, force bool, provider string) (ImportResult, error) {
 	result := ImportResult{}
+	deferRemaining := func(index int) {
+		result.Deferred += len(refs) - index
+		for range refs[index:] {
+			if progress != nil {
+				progress.Skip()
+			}
+		}
+	}
 	existingHash := make(map[string]string)
 	rows, err := i.db.Query(`SELECT session_id, COALESCE(file_hash, '') FROM sessions`)
 	if err != nil {
@@ -559,12 +568,7 @@ func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fe
 	for index, ref := range refs {
 		if err := ctx.Err(); err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				for _, pending := range refs[index:] {
-					result.addFailure(pending.ImportID, err)
-					if progress != nil {
-						progress.Skip()
-					}
-				}
+				deferRemaining(index)
 			}
 			return result, err
 		}
@@ -586,15 +590,16 @@ func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fe
 		}
 
 		session, err := fetch(ctx, ref)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				deferRemaining(index)
+			}
+			return result, ctxErr
+		}
 		if err != nil {
 			if ctx.Err() != nil {
 				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					for _, pending := range refs[index:] {
-						result.addFailure(pending.ImportID, ctx.Err())
-						if progress != nil {
-							progress.Skip()
-						}
-					}
+					deferRemaining(index)
 				}
 				return result, ctx.Err()
 			}
@@ -643,6 +648,12 @@ func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fe
 				}
 			}
 			progress.Update(session.Summary, firstMsg)
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				deferRemaining(index + 1)
+			}
+			return result, ctxErr
 		}
 	}
 

--- a/internal/core/importer/importer.go
+++ b/internal/core/importer/importer.go
@@ -25,7 +25,7 @@ type ImportFailure struct {
 type ImportResult struct {
 	Imported int
 	Skipped  int
-	Deferred int
+	Deferred []string
 	Failures []ImportFailure
 }
 
@@ -538,14 +538,6 @@ func (i *Importer) ImportEnumerated(ctx context.Context, sessions []*ccsessions.
 // export on subsequent syncs.
 func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fetch func(context.Context, RemoteSessionRef) (*ccsessions.ParsedSession, error), progress ProgressCallback, force bool, provider string) (ImportResult, error) {
 	result := ImportResult{}
-	deferRemaining := func(index int) {
-		result.Deferred += len(refs) - index
-		for range refs[index:] {
-			if progress != nil {
-				progress.Skip()
-			}
-		}
-	}
 	existingHash := make(map[string]string)
 	rows, err := i.db.Query(`SELECT session_id, COALESCE(file_hash, '') FROM sessions`)
 	if err != nil {
@@ -564,12 +556,27 @@ func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fe
 		return result, fmt.Errorf("failed to read remote session metadata: %w", err)
 	}
 	_ = rows.Close()
+	deferIfInterrupted := func(index int) error {
+		if err := ctx.Err(); err != nil {
+			for _, pending := range refs[index:] {
+				id := strings.TrimSpace(pending.ImportID)
+				revision := strings.TrimSpace(pending.Revision)
+				if id != "" && revision != "" && !force && existingHash[id] == revision {
+					result.Skipped++
+				} else {
+					result.Deferred = append(result.Deferred, id)
+				}
+				if progress != nil {
+					progress.Skip()
+				}
+			}
+			return err
+		}
+		return nil
+	}
 
 	for index, ref := range refs {
-		if err := ctx.Err(); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				deferRemaining(index)
-			}
+		if err := deferIfInterrupted(index); err != nil {
 			return result, err
 		}
 		ref.ImportID = strings.TrimSpace(ref.ImportID)
@@ -590,19 +597,10 @@ func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fe
 		}
 
 		session, err := fetch(ctx, ref)
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			if errors.Is(ctxErr, context.DeadlineExceeded) {
-				deferRemaining(index)
-			}
-			return result, ctxErr
+		if interruptErr := deferIfInterrupted(index); interruptErr != nil {
+			return result, interruptErr
 		}
 		if err != nil {
-			if ctx.Err() != nil {
-				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					deferRemaining(index)
-				}
-				return result, ctx.Err()
-			}
 			result.addFailure(ref.ImportID, err)
 			if progress != nil {
 				progress.Skip()
@@ -648,12 +646,6 @@ func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fe
 				}
 			}
 			progress.Update(session.Summary, firstMsg)
-		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			if errors.Is(ctxErr, context.DeadlineExceeded) {
-				deferRemaining(index + 1)
-			}
-			return result, ctxErr
 		}
 	}
 

--- a/internal/core/importer/importer.go
+++ b/internal/core/importer/importer.go
@@ -561,7 +561,9 @@ func (i *Importer) ImportRemote(ctx context.Context, refs []RemoteSessionRef, fe
 			for _, pending := range refs[index:] {
 				id := strings.TrimSpace(pending.ImportID)
 				revision := strings.TrimSpace(pending.Revision)
-				if id != "" && revision != "" && !force && existingHash[id] == revision {
+				if id == "" || revision == "" {
+					result.addFailure(id, errors.New("missing id or revision"))
+				} else if !force && existingHash[id] == revision {
 					result.Skipped++
 				} else {
 					result.Deferred = append(result.Deferred, id)

--- a/internal/core/importer/importer_test.go
+++ b/internal/core/importer/importer_test.go
@@ -160,6 +160,12 @@ func (p *unitProgress) Update(string, string) { p.current++ }
 func (p *unitProgress) Skip()                 { p.current++ }
 func (*unitProgress) Finish()                 {}
 
+type cancelOnUpdateProgress struct{ cancel context.CancelFunc }
+
+func (p *cancelOnUpdateProgress) Update(string, string) { p.cancel() }
+func (*cancelOnUpdateProgress) Skip()                   {}
+func (*cancelOnUpdateProgress) Finish()                 {}
+
 func TestPreparedRemoteProgressIncludesFailures(t *testing.T) {
 	database, err := db.New(filepath.Join(t.TempDir(), "progress.db"))
 	if err != nil {
@@ -278,7 +284,7 @@ func TestPreparedOptionalRemoteTimeoutKeepsPartialImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v, want optional timeout to degrade", err)
 	}
-	if result.Imported != 1 || result.Deferred != 2 || len(result.Failures) != 0 || progress.current != 3 {
+	if result.Imported != 1 || !reflect.DeepEqual(result.Deferred, []string{"timed-out", "not-attempted"}) || len(result.Failures) != 0 || progress.current != 3 {
 		t.Fatalf("result = %+v, progress = %d; want partial import, two deferred, 3/3", result, progress.current)
 	}
 	var imported int
@@ -315,7 +321,7 @@ func TestImportRemoteChildDeadlineIsPerSessionFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Imported != 1 || result.Deferred != 0 || len(result.Failures) != 1 {
+	if result.Imported != 1 || len(result.Deferred) != 0 || len(result.Failures) != 1 {
 		t.Fatalf("result = %+v, want one import and one per-session failure", result)
 	}
 	if result.Failures[0].ID != "timed-out" || !errors.Is(result.Failures[0].Err, context.DeadlineExceeded) {
@@ -347,8 +353,8 @@ func TestImportRemoteDoesNotCommitFetchCompletedAfterCallerDeadline(t *testing.T
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ImportRemote() error = %v, want cancellation", err)
 	}
-	if result.Imported != 0 || result.Deferred != 0 || len(result.Failures) != 0 {
-		t.Fatalf("result = %+v, want no committed or synthetic outcome", result)
+	if result.Imported != 0 || !reflect.DeepEqual(result.Deferred, []string{"late"}) || len(result.Failures) != 0 {
+		t.Fatalf("result = %+v, want late session deferred", result)
 	}
 	var count int
 	if err := database.QueryRow(`SELECT COUNT(*) FROM sessions WHERE session_id = 'late'`).Scan(&count); err != nil {
@@ -359,7 +365,7 @@ func TestImportRemoteDoesNotCommitFetchCompletedAfterCallerDeadline(t *testing.T
 	}
 }
 
-func TestImportRemoteCancellationDoesNotFailUntouchedSessions(t *testing.T) {
+func TestImportRemoteCancellationDefersChangedAndSkipsUnchangedSessions(t *testing.T) {
 	database, err := db.New(filepath.Join(t.TempDir(), "remote-cancel.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -368,7 +374,20 @@ func TestImportRemoteCancellationDoesNotFailUntouchedSessions(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	stamp := time.Now().UTC()
-	refs := []RemoteSessionRef{{ImportID: "imported", Revision: "1"}, {ImportID: "cancel", Revision: "1"}, {ImportID: "untouched", Revision: "1"}}
+	imp := New(database)
+	unchanged := []RemoteSessionRef{{ImportID: "unchanged", Revision: "1"}}
+	if _, err := imp.ImportRemote(context.Background(), unchanged, func(_ context.Context, ref RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+		return &ccsessions.ParsedSession{
+			SessionID: ref.ImportID, ProjectPath: "/tmp", FileMtime: stamp,
+			Messages: []ccsessions.ParsedMessage{{
+				UUID: "unchanged-message", Type: "user", Sender: "human", TextContent: "hello", Timestamp: stamp,
+			}},
+		}, nil
+	}, nil, false, ampProvider); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := []RemoteSessionRef{{ImportID: "imported", Revision: "1"}, {ImportID: "cancel", Revision: "1"}, {ImportID: "unchanged", Revision: "1"}, {ImportID: "untouched", Revision: "1"}}
 	fetch := func(_ context.Context, ref RemoteSessionRef) (*ccsessions.ParsedSession, error) {
 		if ref.ImportID == "cancel" {
 			cancel()
@@ -382,12 +401,40 @@ func TestImportRemoteCancellationDoesNotFailUntouchedSessions(t *testing.T) {
 		}, nil
 	}
 	progress := &unitProgress{}
-	result, err := New(database).ImportRemote(ctx, refs, fetch, progress, false, ampProvider)
+	result, err := imp.ImportRemote(ctx, refs, fetch, progress, false, ampProvider)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ImportRemote() error = %v, want context cancellation", err)
 	}
-	if result.Imported != 1 || len(result.Failures) != 0 || progress.current != 1 {
-		t.Fatalf("result = %+v, progress = %d; untouched sessions must not become failures", result, progress.current)
+	if result.Imported != 1 || result.Skipped != 1 || !reflect.DeepEqual(result.Deferred, []string{"cancel", "untouched"}) || len(result.Failures) != 0 || progress.current != 4 {
+		t.Fatalf("result = %+v, progress = %d; want changed sessions deferred and unchanged session skipped", result, progress.current)
+	}
+}
+
+func TestImportRemoteCancellationAfterFinalCommitStillSucceeds(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "final-commit-cancel.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stamp := time.Now().UTC()
+	refs := []RemoteSessionRef{{ImportID: "final", Revision: "1"}}
+	fetch := func(_ context.Context, ref RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+		return &ccsessions.ParsedSession{
+			SessionID: ref.ImportID, ProjectPath: "/tmp", FileMtime: stamp,
+			Messages: []ccsessions.ParsedMessage{{
+				UUID: "final-message", Type: "user", Sender: "human", TextContent: "hello", Timestamp: stamp,
+			}},
+		}, nil
+	}
+
+	result, err := New(database).ImportRemote(ctx, refs, fetch, &cancelOnUpdateProgress{cancel: cancel}, false, ampProvider)
+	if err != nil {
+		t.Fatalf("ImportRemote() error = %v, want successful completed import", err)
+	}
+	if result.Imported != 1 || len(result.Deferred) != 0 || len(result.Failures) != 0 {
+		t.Fatalf("result = %+v, want final session committed without deferral", result)
 	}
 }
 
@@ -412,6 +459,79 @@ func TestSyncAllReportsPerSessionFailures(t *testing.T) {
 	err = New(database).SyncAll(context.Background(), []Source{source}, false)
 	if err == nil || !strings.Contains(err.Error(), "unsupported schema version") {
 		t.Fatalf("SyncAll() error = %v, want structured session failure", err)
+	}
+}
+
+func TestSyncAllReportsDeferredRemoteSessions(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "deferred-sync.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	source := Source{Provider: ampProvider, Optional: true, Remote: &RemoteSource{
+		List: func(context.Context) ([]RemoteSessionRef, error) {
+			return []RemoteSessionRef{{ImportID: "blocked", Revision: "1"}, {ImportID: "pending", Revision: "1"}}, nil
+		},
+		Fetch: func(ctx context.Context, _ RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err = New(database).SyncAll(ctx, []Source{source}, false)
+	if err == nil || !strings.Contains(err.Error(), "2 sessions deferred (blocked, pending)") {
+		t.Fatalf("SyncAll() error = %v, want deferred session signal", err)
+	}
+}
+
+func TestSyncAllReportsCallerDeadlineDuringRemoteList(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "list-deadline-sync.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	source := Source{Provider: ampProvider, Optional: true, Remote: &RemoteSource{
+		List: func(ctx context.Context) ([]RemoteSessionRef, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err = New(database).SyncAll(ctx, []Source{source}, false)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SyncAll() error = %v, want caller deadline", err)
+	}
+}
+
+func TestSyncAllPreservesDeferredDetailsWhenNextPreparationFails(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "joined-sync-errors.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	deferredSource := Source{Provider: ampProvider, Optional: true, Remote: &RemoteSource{
+		List: func(context.Context) ([]RemoteSessionRef, error) {
+			return []RemoteSessionRef{{ImportID: "pending", Revision: "1"}}, nil
+		},
+		Fetch: func(ctx context.Context, _ RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}}
+	nextSource := Source{Provider: "next", Path: t.TempDir()}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err = New(database).SyncAll(ctx, []Source{deferredSource, nextSource}, false)
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "1 sessions deferred (pending)") {
+		t.Fatalf("SyncAll() error = %v, want deferred details joined with caller deadline", err)
 	}
 }
 

--- a/internal/core/importer/importer_test.go
+++ b/internal/core/importer/importer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -191,6 +192,49 @@ func TestPreparedRemoteProgressIncludesFailures(t *testing.T) {
 	}
 }
 
+func TestPreparedRemoteUsesCallerControlledLifetime(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "caller-lifetime.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	assertNoDeadline := func(ctx context.Context) {
+		t.Helper()
+		if deadline, ok := ctx.Deadline(); ok {
+			t.Fatalf("remote context has internal deadline %v; want caller-controlled lifetime", deadline)
+		}
+	}
+	stamp := time.Now().UTC()
+	source := Source{Provider: ampProvider, Remote: &RemoteSource{
+		List: func(ctx context.Context) ([]RemoteSessionRef, error) {
+			assertNoDeadline(ctx)
+			return []RemoteSessionRef{{ImportID: "one", Revision: "1"}}, nil
+		},
+		Fetch: func(ctx context.Context, ref RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+			assertNoDeadline(ctx)
+			return &ccsessions.ParsedSession{
+				SessionID: ref.ImportID, ProjectPath: "/tmp", FileMtime: stamp,
+				Messages: []ccsessions.ParsedMessage{{
+					UUID: "caller-lifetime-message", Type: "user", Sender: "human", TextContent: "hello", Timestamp: stamp,
+				}},
+			}, nil
+		},
+	}}
+
+	prepared, err := New(database).PrepareSource(context.Background(), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := prepared.Run(context.Background(), nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Imported != 1 {
+		t.Fatalf("result = %+v, want one import", result)
+	}
+}
+
 func TestPreparedOptionalRemoteTimeoutKeepsPartialImport(t *testing.T) {
 	database, err := db.New(filepath.Join(t.TempDir(), "partial-timeout.db"))
 	if err != nil {
@@ -234,14 +278,84 @@ func TestPreparedOptionalRemoteTimeoutKeepsPartialImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v, want optional timeout to degrade", err)
 	}
-	if result.Imported != 1 || len(result.Failures) != 2 || progress.current != 3 {
-		t.Fatalf("result = %+v, progress = %d; want partial import, two pending failures, 3/3", result, progress.current)
+	if result.Imported != 1 || result.Deferred != 2 || len(result.Failures) != 0 || progress.current != 3 {
+		t.Fatalf("result = %+v, progress = %d; want partial import, two deferred, 3/3", result, progress.current)
 	}
-	wantFailureIDs := []string{"timed-out", "not-attempted"}
-	for index, failure := range result.Failures {
-		if failure.ID != wantFailureIDs[index] || !errors.Is(failure.Err, context.DeadlineExceeded) {
-			t.Fatalf("failure %d = %+v, want deadline for %q", index, failure, wantFailureIDs[index])
+	var imported int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM sessions WHERE session_id = 'imported'`).Scan(&imported); err != nil {
+		t.Fatal(err)
+	}
+	if imported != 1 {
+		t.Fatalf("committed imported sessions = %d, want 1", imported)
+	}
+}
+
+func TestImportRemoteChildDeadlineIsPerSessionFailure(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "child-timeout.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	refs := []RemoteSessionRef{{ImportID: "timed-out", Revision: "1"}, {ImportID: "next", Revision: "1"}}
+	stamp := time.Now().UTC()
+	fetch := func(_ context.Context, ref RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+		if ref.ImportID == "timed-out" {
+			return nil, fmt.Errorf("command timeout: %w", context.DeadlineExceeded)
 		}
+		return &ccsessions.ParsedSession{
+			SessionID: ref.ImportID, ProjectPath: "/tmp", FileMtime: stamp,
+			Messages: []ccsessions.ParsedMessage{{
+				UUID: "after-child-timeout", Type: "user", Sender: "human", TextContent: "hello", Timestamp: stamp,
+			}},
+		}, nil
+	}
+
+	result, err := New(database).ImportRemote(context.Background(), refs, fetch, nil, false, ampProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Imported != 1 || result.Deferred != 0 || len(result.Failures) != 1 {
+		t.Fatalf("result = %+v, want one import and one per-session failure", result)
+	}
+	if result.Failures[0].ID != "timed-out" || !errors.Is(result.Failures[0].Err, context.DeadlineExceeded) {
+		t.Fatalf("failure = %+v, want timed-out deadline", result.Failures[0])
+	}
+}
+
+func TestImportRemoteDoesNotCommitFetchCompletedAfterCallerDeadline(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "late-success.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stamp := time.Now().UTC()
+	refs := []RemoteSessionRef{{ImportID: "late", Revision: "1"}}
+	fetch := func(_ context.Context, ref RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+		cancel()
+		return &ccsessions.ParsedSession{
+			SessionID: ref.ImportID, ProjectPath: "/tmp", FileMtime: stamp,
+			Messages: []ccsessions.ParsedMessage{{
+				UUID: "late-success", Type: "user", Sender: "human", TextContent: "hello", Timestamp: stamp,
+			}},
+		}, nil
+	}
+
+	result, err := New(database).ImportRemote(ctx, refs, fetch, nil, false, ampProvider)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ImportRemote() error = %v, want cancellation", err)
+	}
+	if result.Imported != 0 || result.Deferred != 0 || len(result.Failures) != 0 {
+		t.Fatalf("result = %+v, want no committed or synthetic outcome", result)
+	}
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM sessions WHERE session_id = 'late'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("late session count = %d, want 0", count)
 	}
 }
 

--- a/internal/core/importer/importer_test.go
+++ b/internal/core/importer/importer_test.go
@@ -154,6 +154,76 @@ func TestDefaultSourcesOmitsAmpUntilEnabled(t *testing.T) {
 	}
 }
 
+func TestSyncSourcesRunsLocalsFirstAndBudgetsEachRemote(t *testing.T) {
+	remoteTimeout := time.Second
+	sources := []Source{
+		{Provider: "remote-one", Remote: &RemoteSource{}},
+		{Provider: "local"},
+		{Provider: "remote-two", Remote: &RemoteSource{}},
+	}
+	var order []string
+	var remoteDeadlines []time.Time
+
+	err := SyncSources(context.Background(), sources, remoteTimeout, func(ctx context.Context, src Source) error {
+		order = append(order, src.Provider)
+		deadline, hasDeadline := ctx.Deadline()
+		if src.Remote == nil {
+			if hasDeadline {
+				t.Fatalf("local source received remote deadline %v", deadline)
+			}
+			return nil
+		}
+		if !hasDeadline {
+			t.Fatalf("remote source %s has no deadline", src.Provider)
+		}
+		if remaining := time.Until(deadline); remaining <= 0 || remaining > remoteTimeout {
+			t.Fatalf("remote source %s deadline has remaining budget %v, want (0, %v]", src.Provider, remaining, remoteTimeout)
+		}
+		remoteDeadlines = append(remoteDeadlines, deadline)
+		if src.Provider == "remote-one" {
+			time.Sleep(10 * time.Millisecond)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"local", "remote-one", "remote-two"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("source order = %v, want %v", order, want)
+	}
+	if len(remoteDeadlines) != 2 || !remoteDeadlines[1].After(remoteDeadlines[0]) {
+		t.Fatalf("remote deadlines = %v, want a fresh budget for each remote source", remoteDeadlines)
+	}
+}
+
+func TestSyncSourcesZeroDisablesRemoteTimeout(t *testing.T) {
+	err := SyncSources(context.Background(), []Source{{Provider: "remote", Remote: &RemoteSource{}}}, 0, func(ctx context.Context, _ Source) error {
+		if deadline, ok := ctx.Deadline(); ok {
+			t.Fatalf("zero timeout added remote deadline %v", deadline)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncSourcesChecksCancellationBeforeStartingNextSource(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var visited []string
+	err := SyncSources(ctx, []Source{{Provider: "first"}, {Provider: "second"}}, DefaultRemoteSyncTimeout, func(_ context.Context, src Source) error {
+		visited = append(visited, src.Provider)
+		cancel()
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("SyncSources() error = %v, want context cancellation", err)
+	}
+	if want := []string{"first"}; !reflect.DeepEqual(visited, want) {
+		t.Fatalf("visited sources = %v, want %v", visited, want)
+	}
+}
+
 type unitProgress struct{ current int }
 
 func (p *unitProgress) Update(string, string) { p.current++ }
@@ -459,6 +529,43 @@ func TestSyncAllReportsPerSessionFailures(t *testing.T) {
 	err = New(database).SyncAll(context.Background(), []Source{source}, false)
 	if err == nil || !strings.Contains(err.Error(), "unsupported schema version") {
 		t.Fatalf("SyncAll() error = %v, want structured session failure", err)
+	}
+}
+
+func TestSyncAllReportsOptionalPreparationWarningsAndContinues(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "optional-warning.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	listErr := errors.New("Amp authentication failed")
+	continued := false
+	sources := []Source{
+		{
+			Provider: ampProvider,
+			Optional: true,
+			Remote: &RemoteSource{
+				List: func(context.Context) ([]RemoteSessionRef, error) { return nil, listErr },
+			},
+		},
+		{
+			Provider: "later",
+			Remote: &RemoteSource{
+				List: func(context.Context) ([]RemoteSessionRef, error) {
+					continued = true
+					return nil, nil
+				},
+			},
+		},
+	}
+
+	err = New(database).SyncAll(context.Background(), sources, false)
+	if !continued {
+		t.Fatal("SyncAll() stopped after optional preparation warning")
+	}
+	if !errors.Is(err, listErr) || !strings.Contains(err.Error(), "amp sync skipped") {
+		t.Fatalf("SyncAll() error = %v, want provider-qualified optional warning", err)
 	}
 }
 

--- a/internal/core/importer/importer_test.go
+++ b/internal/core/importer/importer_test.go
@@ -208,6 +208,84 @@ func TestSyncSourcesZeroDisablesRemoteTimeout(t *testing.T) {
 	}
 }
 
+func TestSyncSourcesOptionalRemoteListDeadlineWarnsAndContinues(t *testing.T) {
+	imp := New(nil)
+	continued := false
+	var warning error
+	sources := []Source{
+		{
+			Provider: "optional",
+			Optional: true,
+			Remote: &RemoteSource{List: func(ctx context.Context) ([]RemoteSessionRef, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}},
+		},
+		{
+			Provider: "later",
+			Remote: &RemoteSource{List: func(context.Context) ([]RemoteSessionRef, error) {
+				continued = true
+				return nil, nil
+			}},
+		},
+	}
+
+	err := SyncSources(context.Background(), sources, 10*time.Millisecond, func(ctx context.Context, src Source) error {
+		prepared, err := imp.PrepareSource(ctx, src)
+		if err != nil {
+			return err
+		}
+		if prepared.Warning != nil {
+			warning = prepared.Warning
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("SyncSources() error = %v, want degraded optional timeout", err)
+	}
+	if !errors.Is(warning, context.DeadlineExceeded) {
+		t.Fatalf("warning = %v, want optional source deadline", warning)
+	}
+	if !continued {
+		t.Fatal("later remote source did not run after optional list timeout")
+	}
+}
+
+func TestSyncSourcesPropagatesParentDeadlineDuringOptionalRemoteList(t *testing.T) {
+	imp := New(nil)
+	continued := false
+	sources := []Source{
+		{
+			Provider: "optional",
+			Optional: true,
+			Remote: &RemoteSource{List: func(ctx context.Context) ([]RemoteSessionRef, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}},
+		},
+		{
+			Provider: "later",
+			Remote: &RemoteSource{List: func(context.Context) ([]RemoteSessionRef, error) {
+				continued = true
+				return nil, nil
+			}},
+		},
+	}
+	parent, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := SyncSources(parent, sources, time.Second, func(ctx context.Context, src Source) error {
+		_, err := imp.PrepareSource(ctx, src)
+		return err
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SyncSources() error = %v, want parent deadline", err)
+	}
+	if continued {
+		t.Fatal("later remote source ran after parent deadline")
+	}
+}
+
 func TestSyncSourcesChecksCancellationBeforeStartingNextSource(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var visited []string
@@ -477,6 +555,36 @@ func TestImportRemoteCancellationDefersChangedAndSkipsUnchangedSessions(t *testi
 	}
 	if result.Imported != 1 || result.Skipped != 1 || !reflect.DeepEqual(result.Deferred, []string{"cancel", "untouched"}) || len(result.Failures) != 0 || progress.current != 4 {
 		t.Fatalf("result = %+v, progress = %d; want changed sessions deferred and unchanged session skipped", result, progress.current)
+	}
+}
+
+func TestImportRemoteInterruptionKeepsInvalidRefsAsFailures(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "invalid-interrupted-refs.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	refs := []RemoteSessionRef{
+		{ImportID: "", Revision: "1"},
+		{ImportID: "missing-revision", Revision: ""},
+		{ImportID: "retryable", Revision: "1"},
+	}
+	progress := &unitProgress{}
+	result, err := New(database).ImportRemote(ctx, refs, func(context.Context, RemoteSessionRef) (*ccsessions.ParsedSession, error) {
+		t.Fatal("fetch called after interruption")
+		return nil, nil
+	}, progress, false, ampProvider)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ImportRemote() error = %v, want context cancellation", err)
+	}
+	if !reflect.DeepEqual(result.Deferred, []string{"retryable"}) || len(result.Failures) != 2 || progress.current != 3 {
+		t.Fatalf("result = %+v, progress = %d; want invalid failures and one retryable deferral", result, progress.current)
+	}
+	if result.Failures[0].ID != "" || result.Failures[1].ID != "missing-revision" {
+		t.Fatalf("failures = %+v, want invalid refs classified by ID", result.Failures)
 	}
 }
 

--- a/internal/core/importer/sync.go
+++ b/internal/core/importer/sync.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/neilberkman/ccrider/pkg/antigravitysessions"
 	"github.com/neilberkman/ccrider/pkg/ccsessions"
@@ -16,6 +17,10 @@ import (
 	"github.com/neilberkman/ccrider/pkg/opencodesessions"
 	"github.com/neilberkman/ccrider/pkg/pisessions"
 )
+
+// DefaultRemoteSyncTimeout is the standard total budget for one remote source.
+// Interfaces may override it when their protocol has a different lifetime.
+const DefaultRemoteSyncTimeout = 10 * time.Minute
 
 // EnumerateFunc returns all parsed sessions for a database/event-log-backed
 // provider (e.g. Copilot, OpenCode) that does not store one JSONL file per
@@ -264,6 +269,37 @@ func skippedPreparedSource(src Source, warning error) PreparedSource {
 	}
 }
 
+// SyncSources runs local sources first, then gives each remote source its own
+// total budget. A zero timeout disables the remote budget. The callback owns
+// source preparation, import, and interface-specific reporting.
+func SyncSources(ctx context.Context, sources []Source, remoteTimeout time.Duration, syncSource func(context.Context, Source) error) error {
+	if remoteTimeout < 0 {
+		return errors.New("remote sync timeout must not be negative")
+	}
+	for _, remote := range []bool{false, true} {
+		for _, src := range sources {
+			if (src.Remote != nil) != remote {
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			sourceCtx := ctx
+			cancel := func() {}
+			if remote && remoteTimeout > 0 {
+				sourceCtx, cancel = context.WithTimeout(ctx, remoteTimeout)
+			}
+			err := syncSource(sourceCtx, src)
+			cancel()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // CountJSONLFiles counts importable .jsonl files under dirPath, applying the
 // same subagent/edit-conflict exclusions ImportDirectory uses.
 func CountJSONLFiles(dirPath string, skipSubagents bool) (int, error) {
@@ -301,6 +337,7 @@ func (i *Importer) SyncAll(ctx context.Context, sources []Source, force bool) er
 			return errors.Join(failures...)
 		}
 		if prepared.Warning != nil {
+			failures = append(failures, fmt.Errorf("%s sync skipped: %w", prepared.Provider, prepared.Warning))
 			continue
 		}
 		result, runErr := prepared.Run(ctx, nil, force)

--- a/internal/core/importer/sync.go
+++ b/internal/core/importer/sync.go
@@ -181,16 +181,18 @@ func (i *Importer) PrepareSource(ctx context.Context, src Source) (PreparedSourc
 		return PreparedSource{}, err
 	}
 	if src.Remote != nil {
-		// Remote clients bound each network command. Keep the overall lifetime
-		// caller-controlled so an interactive initial sync can scale to accounts
-		// with more sessions than an arbitrary account-wide timeout permits.
+		// Remote clients bound each network command. The caller (normally
+		// SyncSources) controls the source-wide lifetime.
 		refs, err := src.Remote.List(ctx)
 		if err != nil {
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return PreparedSource{}, ctxErr
-			}
+			// A source-wide deadline is an expected degraded outcome for an
+			// optional remote provider. Parent cancellation is still propagated
+			// by SyncSources after the callback returns.
 			if src.Optional && errors.Is(err, context.DeadlineExceeded) {
 				return skippedPreparedSource(src, err), nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return PreparedSource{}, ctxErr
 			}
 			if src.Optional {
 				return skippedPreparedSource(src, err), nil
@@ -293,6 +295,9 @@ func SyncSources(ctx context.Context, sources []Source, remoteTimeout time.Durat
 			err := syncSource(sourceCtx, src)
 			cancel()
 			if err != nil {
+				return err
+			}
+			if err := ctx.Err(); err != nil {
 				return err
 			}
 		}

--- a/internal/core/importer/sync.go
+++ b/internal/core/importer/sync.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/neilberkman/ccrider/pkg/antigravitysessions"
 	"github.com/neilberkman/ccrider/pkg/ccsessions"
@@ -17,8 +16,6 @@ import (
 	"github.com/neilberkman/ccrider/pkg/opencodesessions"
 	"github.com/neilberkman/ccrider/pkg/pisessions"
 )
-
-const remoteSyncTimeout = 2 * time.Minute
 
 // EnumerateFunc returns all parsed sessions for a database/event-log-backed
 // provider (e.g. Copilot, OpenCode) that does not store one JSONL file per
@@ -34,7 +31,9 @@ type RemoteSessionRef struct {
 
 // RemoteSource lists lightweight remote references and fetches one full
 // session on demand. This avoids downloading every remote transcript before
-// the importer can determine which ones are unchanged.
+// the importer can determine which ones are unchanged. Implementations must
+// honor caller cancellation and independently bound each blocking external
+// operation; the importer does not impose an account-wide timeout.
 type RemoteSource struct {
 	List  func(context.Context) ([]RemoteSessionRef, error)
 	Fetch func(context.Context, RemoteSessionRef) (*ccsessions.ParsedSession, error)
@@ -177,10 +176,10 @@ func (i *Importer) PrepareSource(ctx context.Context, src Source) (PreparedSourc
 		return PreparedSource{}, err
 	}
 	if src.Remote != nil {
-		deadline := time.Now().Add(remoteSyncTimeout)
-		listCtx, cancel := context.WithDeadline(ctx, deadline)
-		refs, err := src.Remote.List(listCtx)
-		cancel()
+		// Remote clients bound each network command. Keep the overall lifetime
+		// caller-controlled so an interactive initial sync can scale to accounts
+		// with more sessions than an arbitrary account-wide timeout permits.
+		refs, err := src.Remote.List(ctx)
 		if err != nil {
 			if src.Optional && errors.Is(err, context.DeadlineExceeded) {
 				return skippedPreparedSource(src, err), nil
@@ -193,23 +192,12 @@ func (i *Importer) PrepareSource(ctx context.Context, src Source) (PreparedSourc
 			}
 			return PreparedSource{}, err
 		}
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			if src.Optional {
-				return skippedPreparedSource(src, context.DeadlineExceeded), nil
-			}
-			return PreparedSource{}, context.DeadlineExceeded
-		}
 		return PreparedSource{
 			Provider: src.Provider,
 			Path:     src.Path,
 			Total:    len(refs),
 			run: func(ctx context.Context, progress ProgressCallback, force bool) (ImportResult, error) {
-				// Count list and export execution toward the whole remote budget,
-				// but not time a prepared source waits behind another provider.
-				remoteCtx, cancel := context.WithTimeout(ctx, remaining)
-				defer cancel()
-				result, err := i.ImportRemote(remoteCtx, refs, src.Remote.Fetch, progress, force, src.Provider)
+				result, err := i.ImportRemote(ctx, refs, src.Remote.Fetch, progress, force, src.Provider)
 				if src.Optional && errors.Is(err, context.DeadlineExceeded) {
 					return result, nil
 				}

--- a/internal/core/importer/sync.go
+++ b/internal/core/importer/sync.go
@@ -181,11 +181,11 @@ func (i *Importer) PrepareSource(ctx context.Context, src Source) (PreparedSourc
 		// with more sessions than an arbitrary account-wide timeout permits.
 		refs, err := src.Remote.List(ctx)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return PreparedSource{}, ctxErr
+			}
 			if src.Optional && errors.Is(err, context.DeadlineExceeded) {
 				return skippedPreparedSource(src, err), nil
-			}
-			if ctx.Err() != nil {
-				return PreparedSource{}, ctx.Err()
 			}
 			if src.Optional {
 				return skippedPreparedSource(src, err), nil
@@ -297,18 +297,30 @@ func (i *Importer) SyncAll(ctx context.Context, sources []Source, force bool) er
 	for _, src := range sources {
 		prepared, err := i.PrepareSource(ctx, src)
 		if err != nil {
-			return err
+			failures = append(failures, err)
+			return errors.Join(failures...)
 		}
 		if prepared.Warning != nil {
 			continue
 		}
-		result, err := prepared.Run(ctx, nil, force)
-		if err != nil {
-			return err
-		}
+		result, runErr := prepared.Run(ctx, nil, force)
 		for _, failure := range result.Failures {
 			failures = append(failures, fmt.Errorf("%s %s: %w", src.Provider, failure.ID, failure.Err))
 		}
+		if len(result.Deferred) > 0 {
+			failures = append(failures, fmt.Errorf("%s sync incomplete: %d sessions deferred (%s)", src.Provider, len(result.Deferred), summarizeIDs(result.Deferred, 5)))
+		}
+		if runErr != nil {
+			failures = append(failures, runErr)
+			return errors.Join(failures...)
+		}
 	}
 	return errors.Join(failures...)
+}
+
+func summarizeIDs(ids []string, limit int) string {
+	if len(ids) <= limit {
+		return strings.Join(ids, ", ")
+	}
+	return fmt.Sprintf("%s, and %d more", strings.Join(ids[:limit], ", "), len(ids)-limit)
 }

--- a/internal/interface/cli/sync.go
+++ b/internal/interface/cli/sync.go
@@ -22,8 +22,6 @@ var (
 	syncTimeout time.Duration
 )
 
-const defaultRemoteSyncTimeout = 10 * time.Minute
-
 var syncCmd = &cobra.Command{
 	Use:   "sync [path]",
 	Short: "Import/sync coding agent sessions",
@@ -40,7 +38,7 @@ Use --force to re-import all sessions (fixes stale project_path values).`,
 
 func init() {
 	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "Force re-import of all sessions")
-	syncCmd.Flags().DurationVar(&syncTimeout, "sync-timeout", defaultRemoteSyncTimeout, "Maximum time per remote provider sync (0 disables)")
+	syncCmd.Flags().DurationVar(&syncTimeout, "sync-timeout", importer.DefaultRemoteSyncTimeout, "Maximum time per remote provider sync (0 disables)")
 	rootCmd.AddCommand(syncCmd)
 }
 
@@ -114,25 +112,17 @@ func runSync(cmd *cobra.Command, args []string) error {
 		sources = importer.DefaultSources(cfg.AmpEnabled)
 	}
 
-	for _, src := range sources {
-		sourceCtx := cmd.Context()
-		cancel := func() {}
-		if src.Remote != nil && syncTimeout > 0 {
-			sourceCtx, cancel = context.WithTimeout(sourceCtx, syncTimeout)
-		}
+	return importer.SyncSources(cmd.Context(), sources, syncTimeout, func(sourceCtx context.Context, src importer.Source) error {
 		prepared, err := imp.PrepareSource(sourceCtx, src)
 		if err != nil {
-			cancel()
 			return fmt.Errorf("failed to prepare %s sessions: %w", src.Provider, err)
 		}
 		if prepared.Warning != nil {
-			cancel()
 			fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", prepared.Provider, prepared.Warning)
-			continue
+			return nil
 		}
 		if prepared.Total == 0 {
-			cancel()
-			continue
+			return nil
 		}
 
 		fmt.Fprintf(os.Stderr, "Syncing %s sessions from: %s\n", prepared.Provider, prepared.Path)
@@ -140,7 +130,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 		interactive := statErr == nil && stat.Mode()&os.ModeCharDevice != 0
 		progress := importer.NewProgressReporter(os.Stderr, prepared.Total, interactive)
 		result, runErr := prepared.Run(sourceCtx, progress, syncForce)
-		cancel()
 		progress.Finish()
 		for _, failure := range result.Failures {
 			fmt.Fprintf(os.Stderr, "WARN: Cannot import %s session %s: %v\n", src.Provider, failure.ID, failure.Err)
@@ -160,9 +149,8 @@ func runSync(cmd *cobra.Command, args []string) error {
 		if runErr != nil {
 			return fmt.Errorf("%s import failed: %w", src.Provider, runErr)
 		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func deferredIDs(ids []string, limit int) string {

--- a/internal/interface/cli/sync.go
+++ b/internal/interface/cli/sync.go
@@ -128,6 +128,9 @@ func runSync(cmd *cobra.Command, args []string) error {
 		for _, failure := range result.Failures {
 			fmt.Fprintf(os.Stderr, "WARN: Cannot import %s session %s: %v\n", src.Provider, failure.ID, failure.Err)
 		}
+		if result.Deferred > 0 {
+			fmt.Fprintf(os.Stderr, "WARN: %s sync deadline reached; deferred %d sessions until the next sync\n", src.Provider, result.Deferred)
+		}
 
 		if result.Skipped > 0 && !syncForce {
 			skipRate := float64(result.Skipped) / float64(prepared.Total) * 100

--- a/internal/interface/cli/sync.go
+++ b/internal/interface/cli/sync.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/neilberkman/ccrider/internal/core/config"
 	"github.com/neilberkman/ccrider/internal/core/db"
@@ -14,8 +18,11 @@ import (
 )
 
 var (
-	syncForce bool
+	syncForce   bool
+	syncTimeout time.Duration
 )
+
+const defaultRemoteSyncTimeout = 10 * time.Minute
 
 var syncCmd = &cobra.Command{
 	Use:   "sync [path]",
@@ -33,10 +40,14 @@ Use --force to re-import all sessions (fixes stale project_path values).`,
 
 func init() {
 	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "Force re-import of all sessions")
+	syncCmd.Flags().DurationVar(&syncTimeout, "sync-timeout", defaultRemoteSyncTimeout, "Maximum time per remote provider sync (0 disables)")
 	rootCmd.AddCommand(syncCmd)
 }
 
 func runSync(cmd *cobra.Command, args []string) error {
+	if syncTimeout < 0 {
+		return errors.New("sync timeout must not be negative")
+	}
 	// Determine source path for explicit Claude JSONL imports.
 	sourcePath := ""
 	if len(args) > 0 {
@@ -104,15 +115,23 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, src := range sources {
-		prepared, err := imp.PrepareSource(cmd.Context(), src)
+		sourceCtx := cmd.Context()
+		cancel := func() {}
+		if src.Remote != nil && syncTimeout > 0 {
+			sourceCtx, cancel = context.WithTimeout(sourceCtx, syncTimeout)
+		}
+		prepared, err := imp.PrepareSource(sourceCtx, src)
 		if err != nil {
+			cancel()
 			return fmt.Errorf("failed to prepare %s sessions: %w", src.Provider, err)
 		}
 		if prepared.Warning != nil {
+			cancel()
 			fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", prepared.Provider, prepared.Warning)
 			continue
 		}
 		if prepared.Total == 0 {
+			cancel()
 			continue
 		}
 
@@ -120,16 +139,14 @@ func runSync(cmd *cobra.Command, args []string) error {
 		stat, statErr := os.Stderr.Stat()
 		interactive := statErr == nil && stat.Mode()&os.ModeCharDevice != 0
 		progress := importer.NewProgressReporter(os.Stderr, prepared.Total, interactive)
-		result, err := prepared.Run(cmd.Context(), progress, syncForce)
-		if err != nil {
-			return fmt.Errorf("%s import failed: %w", src.Provider, err)
-		}
+		result, runErr := prepared.Run(sourceCtx, progress, syncForce)
+		cancel()
 		progress.Finish()
 		for _, failure := range result.Failures {
 			fmt.Fprintf(os.Stderr, "WARN: Cannot import %s session %s: %v\n", src.Provider, failure.ID, failure.Err)
 		}
-		if result.Deferred > 0 {
-			fmt.Fprintf(os.Stderr, "WARN: %s sync deadline reached; deferred %d sessions until the next sync\n", src.Provider, result.Deferred)
+		if len(result.Deferred) > 0 {
+			fmt.Fprintf(os.Stderr, "WARN: %s sync interrupted; deferred %d changed sessions until the next sync (%s)\n", src.Provider, len(result.Deferred), deferredIDs(result.Deferred, 5))
 		}
 
 		if result.Skipped > 0 && !syncForce {
@@ -140,7 +157,20 @@ func runSync(cmd *cobra.Command, args []string) error {
 			}
 			fmt.Fprintf(os.Stderr, "\nSkipped %d/%d %s %s (%.1f%% unchanged)\n", result.Skipped, prepared.Total, src.Provider, unit, skipRate)
 		}
+		if runErr != nil {
+			return fmt.Errorf("%s import failed: %w", src.Provider, runErr)
+		}
 	}
 
 	return nil
+}
+
+func deferredIDs(ids []string, limit int) string {
+	shown := ids
+	suffix := ""
+	if len(shown) > limit {
+		shown = shown[:limit]
+		suffix = fmt.Sprintf(", and %d more", len(ids)-limit)
+	}
+	return strings.Join(shown, ", ") + suffix
 }

--- a/internal/interface/cli/tui.go
+++ b/internal/interface/cli/tui.go
@@ -34,17 +34,18 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = database.Close() }()
 
-	model := tui.New(database)
+	model := tui.NewWithContext(cmd.Context(), database)
 	p := tea.NewProgram(
 		model,
+		tea.WithContext(cmd.Context()),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
 	)
 
 	finalModel, err := p.Run()
+	model.Close()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error running TUI: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error running TUI: %w", err)
 	}
 
 	// Check if user wants to launch a session

--- a/internal/interface/tui/list_view.go
+++ b/internal/interface/tui/list_view.go
@@ -140,7 +140,7 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.projectFilterEnabled = !m.projectFilterEnabled
 		// Reload sessions with new filter
 		m.sessionsLoadGeneration++
-		return m, loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration)
+		return m, loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration, false)
 
 	case "s":
 		if m.syncing {

--- a/internal/interface/tui/list_view.go
+++ b/internal/interface/tui/list_view.go
@@ -139,13 +139,22 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Toggle project filter
 		m.projectFilterEnabled = !m.projectFilterEnabled
 		// Reload sessions with new filter
-		return m, loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory)
+		m.sessionsLoadGeneration++
+		return m, loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration)
 
 	case "s":
+		if m.syncing {
+			return m, nil
+		}
 		// Trigger sync - save cursor position first
 		m.syncing = true
 		m.savedCursorIndex = m.list.Index()
-		return m, syncSessions(m.db, m.projectFilterEnabled, m.currentDirectory)
+		if selected, ok := m.list.SelectedItem().(sessionListItem); ok {
+			m.savedSessionID = selected.session.ID
+		} else {
+			m.savedSessionID = ""
+		}
+		return m, syncSessions(m.syncManager, m.db)
 
 	case "e":
 		// Open export dialog with repo-aware default path

--- a/internal/interface/tui/list_view.go
+++ b/internal/interface/tui/list_view.go
@@ -148,6 +148,10 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Trigger sync - save cursor position first
 		m.syncing = true
+		m.syncCurrent = 0
+		m.syncTotal = 0
+		m.syncProvider = ""
+		m.syncCurrentFile = ""
 		m.savedCursorIndex = m.list.Index()
 		if selected, ok := m.list.SelectedItem().(sessionListItem); ok {
 			m.savedSessionID = selected.session.ID
@@ -190,8 +194,16 @@ func (m Model) viewList() string {
 	// Build help text / sync status
 	var helpText string
 	if m.syncing && m.syncTotal > 0 {
-		// Show full progress bar like CLI
-		progressBar := renderProgressBar(m.syncCurrent, m.syncTotal, m.width)
+		// Account for the provider label when sizing the progress bar.
+		progressWidth := m.width
+		if m.syncProvider != "" {
+			progressWidth -= len("Syncing " + m.syncProvider + " ")
+		}
+		progressBar := renderProgressBar(m.syncCurrent, m.syncTotal, progressWidth)
+		progressStatus := progressBar
+		if m.syncProvider != "" {
+			progressStatus = fmt.Sprintf("Syncing %s %s", m.syncProvider, progressBar)
+		}
 		sessionInfo := ""
 		if m.syncCurrentFile != "" {
 			sessionInfo = " | " + m.syncCurrentFile
@@ -200,7 +212,7 @@ func (m Model) viewList() string {
 			// Account for progress bar length (already uses most of m.width)
 			// Progress bar format: "[====>    ] 5/10" is roughly 20 chars + bar width
 			// Leave room for the separator and ensure no overflow
-			maxSessionLen := m.width - len(progressBar) - 3 // -3 for safety margin
+			maxSessionLen := m.width - len(progressStatus) - 3 // -3 for safety margin
 			if maxSessionLen < 10 {
 				maxSessionLen = 10 // Minimum useful length
 			}
@@ -208,7 +220,7 @@ func (m Model) viewList() string {
 				sessionInfo = sessionInfo[:maxSessionLen-3] + "..."
 			}
 		}
-		helpText = progressBar + sessionInfo
+		helpText = progressStatus + sessionInfo
 	} else if m.syncing {
 		helpText = "⏳ Syncing..."
 	} else {

--- a/internal/interface/tui/messages.go
+++ b/internal/interface/tui/messages.go
@@ -223,13 +223,12 @@ func loadSessionDetail(database *db.DB, sessionID string) tea.Cmd {
 type syncProgressMsg struct {
 	current     int
 	total       int
+	provider    string
 	sessionName string
 	ch          chan syncProgressMsg
 }
 
 type syncFinishedMsg struct{}
-
-const defaultRemoteSyncTimeout = 10 * time.Minute
 
 type syncManager struct {
 	ctx    context.Context
@@ -282,19 +281,18 @@ func startSyncWithProgress(manager *syncManager, database *db.DB) tea.Cmd {
 		progress := &channelProgressReporter{ch: progressCh}
 		cfg, _ := config.Load()
 		sources := importer.DefaultSources(cfg.AmpEnabled)
-		var remoteSources []importer.Source
 
-		runSource := func(sourceCtx context.Context, src importer.Source) {
+		_ = importer.SyncSources(parent, sources, importer.DefaultRemoteSyncTimeout, func(sourceCtx context.Context, src importer.Source) error {
 			p, err := imp.PrepareSource(sourceCtx, src)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", src.Provider, err)
-				return
+				return nil
 			}
 			if p.Warning != nil {
 				fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", p.Provider, p.Warning)
-				return
+				return nil
 			}
-			progress.addTotal(p.Total)
+			progress.beginSource(p.Provider, p.Total)
 			result, err := p.Run(sourceCtx, progress, false)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "WARN: %s sync failed: %v\n", p.Provider, err)
@@ -305,27 +303,8 @@ func startSyncWithProgress(manager *syncManager, database *db.DB) tea.Cmd {
 			if len(result.Deferred) > 0 {
 				fmt.Fprintf(os.Stderr, "WARN: %s sync interrupted; deferred %d changed sessions until the next sync (%s)\n", p.Provider, len(result.Deferred), deferredIDs(result.Deferred, 5))
 			}
-		}
-
-		// Run local providers first without consuming a remote provider's budget.
-		for _, src := range sources {
-			if src.Remote != nil {
-				remoteSources = append(remoteSources, src)
-				continue
-			}
-			runSource(parent, src)
-			if parent.Err() != nil {
-				return
-			}
-		}
-		for _, src := range remoteSources {
-			sourceCtx, cancel := context.WithTimeout(parent, defaultRemoteSyncTimeout)
-			runSource(sourceCtx, src)
-			cancel()
-			if parent.Err() != nil {
-				return
-			}
-		}
+			return nil
+		})
 	}, func() { close(progressCh) }) {
 		return nil
 	}
@@ -335,6 +314,7 @@ func startSyncWithProgress(manager *syncManager, database *db.DB) tea.Cmd {
 type channelProgressReporter struct {
 	total    int
 	current  int
+	provider string
 	lastName string
 	ch       chan syncProgressMsg
 }
@@ -352,8 +332,11 @@ func (r *channelProgressReporter) Skip() {
 	r.send()
 }
 
-func (r *channelProgressReporter) addTotal(count int) {
-	r.total += count
+func (r *channelProgressReporter) beginSource(provider string, total int) {
+	r.provider = provider
+	r.total = total
+	r.current = 0
+	r.lastName = ""
 	r.send()
 }
 
@@ -365,6 +348,7 @@ func (r *channelProgressReporter) send() {
 	case r.ch <- syncProgressMsg{
 		current:     r.current,
 		total:       r.total,
+		provider:    r.provider,
 		sessionName: r.lastName,
 	}:
 	default:

--- a/internal/interface/tui/messages.go
+++ b/internal/interface/tui/messages.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -20,8 +19,9 @@ type errMsg struct {
 }
 
 type sessionsLoadedMsg struct {
-	sessions   []sessionItem
-	generation uint64
+	sessions         []sessionItem
+	generation       uint64
+	restoreSelection bool
 }
 
 type sessionsLoadFailedMsg struct {
@@ -101,13 +101,13 @@ func performSearch(database *db.DB, query string, seq uint64) tea.Cmd {
 	}
 }
 
-func loadSessions(database *db.DB, filterByProject bool, projectPath string, generation uint64) tea.Cmd {
+func loadSessions(database *db.DB, filterByProject bool, projectPath string, generation uint64, restoreSelection bool) tea.Cmd {
 	return func() tea.Msg {
-		return loadSessionsNow(database, filterByProject, projectPath, generation)
+		return loadSessionsNow(database, filterByProject, projectPath, generation, restoreSelection)
 	}
 }
 
-func loadSessionsNow(database *db.DB, filterByProject bool, projectPath string, generation uint64) tea.Msg {
+func loadSessionsNow(database *db.DB, filterByProject bool, projectPath string, generation uint64, restoreSelection bool) tea.Msg {
 	filterPath := ""
 	if filterByProject {
 		filterPath = projectPath
@@ -142,7 +142,7 @@ func loadSessionsNow(database *db.DB, filterByProject bool, projectPath string, 
 		sessions = append(sessions, s)
 	}
 
-	return sessionsLoadedMsg{sessions: sessions, generation: generation}
+	return sessionsLoadedMsg{sessions: sessions, generation: generation, restoreSelection: restoreSelection}
 }
 
 func firstLine(s string, maxLen int) string {
@@ -225,10 +225,17 @@ type syncProgressMsg struct {
 	total       int
 	provider    string
 	sessionName string
-	ch          chan syncProgressMsg
+	ch          chan syncEvent
 }
 
-type syncFinishedMsg struct{}
+type syncFinishedMsg struct {
+	warnings []string
+}
+
+type syncEvent struct {
+	progress *syncProgressMsg
+	finished *syncFinishedMsg
+}
 
 type syncManager struct {
 	ctx    context.Context
@@ -275,37 +282,50 @@ func (m *syncManager) close() {
 
 // startSyncWithProgress starts one tracked sync and listens for its progress.
 func startSyncWithProgress(manager *syncManager, database *db.DB) tea.Cmd {
-	progressCh := make(chan syncProgressMsg, 100)
+	progressCh := make(chan syncEvent, 100)
+	progress := &channelProgressReporter{ch: progressCh}
+	var warnings []string
 	if !manager.start(func(parent context.Context) {
 		imp := importer.New(database)
-		progress := &channelProgressReporter{ch: progressCh}
 		cfg, _ := config.Load()
 		sources := importer.DefaultSources(cfg.AmpEnabled)
 
-		_ = importer.SyncSources(parent, sources, importer.DefaultRemoteSyncTimeout, func(sourceCtx context.Context, src importer.Source) error {
+		err := importer.SyncSources(parent, sources, importer.DefaultRemoteSyncTimeout, func(sourceCtx context.Context, src importer.Source) error {
 			p, err := imp.PrepareSource(sourceCtx, src)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", src.Provider, err)
+				warnings = append(warnings, fmt.Sprintf("%s sync skipped: %v", src.Provider, err))
 				return nil
 			}
 			if p.Warning != nil {
-				fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", p.Provider, p.Warning)
+				warnings = append(warnings, fmt.Sprintf("%s sync skipped: %v", p.Provider, p.Warning))
 				return nil
 			}
 			progress.beginSource(p.Provider, p.Total)
 			result, err := p.Run(sourceCtx, progress, false)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "WARN: %s sync failed: %v\n", p.Provider, err)
+				warnings = append(warnings, fmt.Sprintf("%s sync failed: %v", p.Provider, err))
 			}
-			for _, failure := range result.Failures {
-				fmt.Fprintf(os.Stderr, "WARN: Cannot import %s session %s: %v\n", p.Provider, failure.ID, failure.Err)
+			for index, failure := range result.Failures {
+				if index == 5 {
+					warnings = append(warnings, fmt.Sprintf("%s: %d additional sessions failed", p.Provider, len(result.Failures)-index))
+					break
+				}
+				warnings = append(warnings, fmt.Sprintf("Cannot import %s session %s: %v", p.Provider, failure.ID, failure.Err))
 			}
 			if len(result.Deferred) > 0 {
-				fmt.Fprintf(os.Stderr, "WARN: %s sync interrupted; deferred %d changed sessions until the next sync (%s)\n", p.Provider, len(result.Deferred), deferredIDs(result.Deferred, 5))
+				warnings = append(warnings, fmt.Sprintf("%s sync interrupted; deferred %d changed sessions until the next sync (%s)", p.Provider, len(result.Deferred), deferredIDs(result.Deferred, 5)))
 			}
 			return nil
 		})
-	}, func() { close(progressCh) }) {
+		if err != nil && parent.Err() == nil {
+			warnings = append(warnings, fmt.Sprintf("sync stopped: %v", err))
+		}
+	}, func() {
+		// The manager is inactive before completion becomes observable, so an
+		// immediate follow-up sync cannot be rejected and leave the UI stuck.
+		progress.complete(warnings)
+		close(progressCh)
+	}) {
 		return nil
 	}
 	return syncSubscribe(progressCh)
@@ -316,7 +336,7 @@ type channelProgressReporter struct {
 	current  int
 	provider string
 	lastName string
-	ch       chan syncProgressMsg
+	ch       chan syncEvent
 }
 
 func (r *channelProgressReporter) Update(sessionSummary string, firstMsg string) {
@@ -342,28 +362,44 @@ func (r *channelProgressReporter) beginSource(provider string, total int) {
 
 // send publishes progress without blocking: every message carries the absolute
 // counter, so dropping intermediate updates when the UI is behind costs nothing
-// but keeps the import from stalling on the render loop.
+// but keeps the import from stalling on the render loop. One buffer slot stays
+// reserved for the completion event so warnings cannot be lost.
 func (r *channelProgressReporter) send() {
-	select {
-	case r.ch <- syncProgressMsg{
+	msg := syncProgressMsg{
 		current:     r.current,
 		total:       r.total,
 		provider:    r.provider,
 		sessionName: r.lastName,
-	}:
+	}
+	if len(r.ch) >= cap(r.ch)-1 {
+		return
+	}
+	select {
+	case r.ch <- syncEvent{progress: &msg}:
 	default:
 	}
+}
+
+// complete uses the slot reserved by send so the terminal event is guaranteed
+// to reach the UI even when it fell behind on progress updates.
+func (r *channelProgressReporter) complete(warnings []string) {
+	finished := syncFinishedMsg{warnings: warnings}
+	r.ch <- syncEvent{finished: &finished}
 }
 
 func (r *channelProgressReporter) Finish() {}
 
 // syncSubscribe listens to the progress channel and returns the next message
-func syncSubscribe(progressCh chan syncProgressMsg) tea.Cmd {
+func syncSubscribe(progressCh chan syncEvent) tea.Cmd {
 	return func() tea.Msg {
-		msg, ok := <-progressCh
+		event, ok := <-progressCh
 		if !ok {
 			return syncFinishedMsg{}
 		}
+		if event.finished != nil {
+			return *event.finished
+		}
+		msg := *event.progress
 		msg.ch = progressCh
 		return msg
 	}

--- a/internal/interface/tui/messages.go
+++ b/internal/interface/tui/messages.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -19,7 +20,13 @@ type errMsg struct {
 }
 
 type sessionsLoadedMsg struct {
-	sessions []sessionItem
+	sessions   []sessionItem
+	generation uint64
+}
+
+type sessionsLoadFailedMsg struct {
+	err        error
+	generation uint64
 }
 
 type sessionDetailLoadedMsg struct {
@@ -94,49 +101,48 @@ func performSearch(database *db.DB, query string, seq uint64) tea.Cmd {
 	}
 }
 
-func loadSessions(database *db.DB, filterByProject bool, projectPath string) tea.Cmd {
+func loadSessions(database *db.DB, filterByProject bool, projectPath string, generation uint64) tea.Cmd {
 	return func() tea.Msg {
-		// Use core function to get sessions
-		filterPath := ""
-		if filterByProject {
-			filterPath = projectPath
-		}
-
-		coreSessions, err := database.ListSessions(filterPath)
-		if err != nil {
-			return errMsg{err}
-		}
-
-		// Convert core sessions to TUI session items (interface-specific presentation)
-		var sessions []sessionItem
-		for _, cs := range coreSessions {
-			// Core already handles summary fallback, just format for display
-			summary := cs.Summary
-			if summary != "" {
-				summary = firstLine(summary, 80)
-			}
-
-			s := sessionItem{
-				ID:           cs.SessionID,
-				Summary:      summary,
-				Project:      cs.ProjectPath,
-				LastCwd:      cs.LastCwd,
-				MessageCount: cs.MessageCount,
-				UpdatedAt:    cs.UpdatedAt.Format(time.RFC3339),
-				CreatedAt:    cs.CreatedAt.Format(time.RFC3339),
-				Provider:     cs.Provider,
-			}
-
-			// Check if session's last cwd matches current directory (for highlighting)
-			if projectPath != "" && strings.Contains(s.LastCwd, projectPath) {
-				s.MatchesCurrentDir = true
-			}
-
-			sessions = append(sessions, s)
-		}
-
-		return sessionsLoadedMsg{sessions}
+		return loadSessionsNow(database, filterByProject, projectPath, generation)
 	}
+}
+
+func loadSessionsNow(database *db.DB, filterByProject bool, projectPath string, generation uint64) tea.Msg {
+	filterPath := ""
+	if filterByProject {
+		filterPath = projectPath
+	}
+
+	coreSessions, err := database.ListSessions(filterPath)
+	if err != nil {
+		return sessionsLoadFailedMsg{err: err, generation: generation}
+	}
+
+	var sessions []sessionItem
+	for _, cs := range coreSessions {
+		summary := cs.Summary
+		if summary != "" {
+			summary = firstLine(summary, 80)
+		}
+
+		s := sessionItem{
+			ID:           cs.SessionID,
+			Summary:      summary,
+			Project:      cs.ProjectPath,
+			LastCwd:      cs.LastCwd,
+			MessageCount: cs.MessageCount,
+			UpdatedAt:    cs.UpdatedAt.Format(time.RFC3339),
+			CreatedAt:    cs.CreatedAt.Format(time.RFC3339),
+			Provider:     cs.Provider,
+		}
+
+		if projectPath != "" && strings.Contains(s.LastCwd, projectPath) {
+			s.MatchesCurrentDir = true
+		}
+		sessions = append(sessions, s)
+	}
+
+	return sessionsLoadedMsg{sessions: sessions, generation: generation}
 }
 
 func firstLine(s string, maxLen int) string {
@@ -215,70 +221,115 @@ func loadSessionDetail(database *db.DB, sessionID string) tea.Cmd {
 }
 
 type syncProgressMsg struct {
-	current         int
-	total           int
-	sessionName     string
-	ch              chan syncProgressMsg
-	db              *db.DB
-	filterByProject bool
-	projectPath     string
+	current     int
+	total       int
+	sessionName string
+	ch          chan syncProgressMsg
 }
 
-// StartSyncWithProgress initiates a sync and returns a command that listens for progress
-func startSyncWithProgress(database *db.DB, filterByProject bool, projectPath string) tea.Cmd {
-	return func() tea.Msg {
-		imp := importer.New(database)
-		ctx := context.Background()
+type syncFinishedMsg struct{}
 
-		// Resolve each source (count work + import action) via core. Sources that
-		// fail to prepare (e.g. an unreadable Copilot store) are surfaced as a
-		// warning rather than silently dropped.
-		var prepared []importer.PreparedSource
-		var total int
+const defaultRemoteSyncTimeout = 10 * time.Minute
+
+type syncManager struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	mu     sync.Mutex
+	wg     sync.WaitGroup
+	active bool
+	closed bool
+}
+
+func newSyncManager(parent context.Context) *syncManager {
+	ctx, cancel := context.WithCancel(parent)
+	return &syncManager{ctx: ctx, cancel: cancel}
+}
+
+func (m *syncManager) start(work func(context.Context), onDone func()) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active || m.closed {
+		return false
+	}
+	m.active = true
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		work(m.ctx)
+		m.mu.Lock()
+		m.active = false
+		m.mu.Unlock()
+		if onDone != nil {
+			onDone()
+		}
+	}()
+	return true
+}
+
+func (m *syncManager) close() {
+	m.mu.Lock()
+	m.closed = true
+	m.cancel()
+	m.mu.Unlock()
+	m.wg.Wait()
+}
+
+// startSyncWithProgress starts one tracked sync and listens for its progress.
+func startSyncWithProgress(manager *syncManager, database *db.DB) tea.Cmd {
+	progressCh := make(chan syncProgressMsg, 100)
+	if !manager.start(func(parent context.Context) {
+		imp := importer.New(database)
+		progress := &channelProgressReporter{ch: progressCh}
 		cfg, _ := config.Load()
-		for _, src := range importer.DefaultSources(cfg.AmpEnabled) {
-			p, err := imp.PrepareSource(ctx, src)
+		sources := importer.DefaultSources(cfg.AmpEnabled)
+		var remoteSources []importer.Source
+
+		runSource := func(sourceCtx context.Context, src importer.Source) {
+			p, err := imp.PrepareSource(sourceCtx, src)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", src.Provider, err)
-				continue
+				return
 			}
 			if p.Warning != nil {
 				fmt.Fprintf(os.Stderr, "WARN: %s sync skipped: %v\n", p.Provider, p.Warning)
+				return
+			}
+			progress.addTotal(p.Total)
+			result, err := p.Run(sourceCtx, progress, false)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: %s sync failed: %v\n", p.Provider, err)
+			}
+			for _, failure := range result.Failures {
+				fmt.Fprintf(os.Stderr, "WARN: Cannot import %s session %s: %v\n", p.Provider, failure.ID, failure.Err)
+			}
+			if len(result.Deferred) > 0 {
+				fmt.Fprintf(os.Stderr, "WARN: %s sync interrupted; deferred %d changed sessions until the next sync (%s)\n", p.Provider, len(result.Deferred), deferredIDs(result.Deferred, 5))
+			}
+		}
+
+		// Run local providers first without consuming a remote provider's budget.
+		for _, src := range sources {
+			if src.Remote != nil {
+				remoteSources = append(remoteSources, src)
 				continue
 			}
-			prepared = append(prepared, p)
-			total += p.Total
-		}
-
-		progressCh := make(chan syncProgressMsg, 100)
-		progressCh <- syncProgressMsg{
-			current:     0,
-			total:       total,
-			sessionName: "",
-		}
-
-		go func() {
-			progress := &channelProgressReporter{
-				total:   total,
-				current: 0,
-				ch:      progressCh,
+			runSource(parent, src)
+			if parent.Err() != nil {
+				return
 			}
-
-			for _, p := range prepared {
-				result, err := p.Run(ctx, progress, false)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "WARN: %s sync failed: %v\n", p.Provider, err)
-				}
-				for _, failure := range result.Failures {
-					fmt.Fprintf(os.Stderr, "WARN: Cannot import %s session %s: %v\n", p.Provider, failure.ID, failure.Err)
-				}
+		}
+		for _, src := range remoteSources {
+			sourceCtx, cancel := context.WithTimeout(parent, defaultRemoteSyncTimeout)
+			runSource(sourceCtx, src)
+			cancel()
+			if parent.Err() != nil {
+				return
 			}
-
-			close(progressCh)
-		}()
-
-		return syncSubscribe(progressCh, database, filterByProject, projectPath)()
+		}
+	}, func() { close(progressCh) }) {
+		return nil
 	}
+	return syncSubscribe(progressCh)
 }
 
 type channelProgressReporter struct {
@@ -301,6 +352,11 @@ func (r *channelProgressReporter) Skip() {
 	r.send()
 }
 
+func (r *channelProgressReporter) addTotal(count int) {
+	r.total += count
+	r.send()
+}
+
 // send publishes progress without blocking: every message carries the absolute
 // counter, so dropping intermediate updates when the UI is behind costs nothing
 // but keeps the import from stalling on the render loop.
@@ -318,22 +374,27 @@ func (r *channelProgressReporter) send() {
 func (r *channelProgressReporter) Finish() {}
 
 // syncSubscribe listens to the progress channel and returns the next message
-func syncSubscribe(progressCh chan syncProgressMsg, database *db.DB, filterByProject bool, projectPath string) tea.Cmd {
+func syncSubscribe(progressCh chan syncProgressMsg) tea.Cmd {
 	return func() tea.Msg {
 		msg, ok := <-progressCh
 		if !ok {
-			// Channel closed, sync is done
-			return loadSessions(database, filterByProject, projectPath)()
+			return syncFinishedMsg{}
 		}
-		// Add the channel and db info so we can chain the next subscription
 		msg.ch = progressCh
-		msg.db = database
-		msg.filterByProject = filterByProject
-		msg.projectPath = projectPath
 		return msg
 	}
 }
 
-func syncSessions(database *db.DB, filterByProject bool, projectPath string) tea.Cmd {
-	return startSyncWithProgress(database, filterByProject, projectPath)
+func syncSessions(manager *syncManager, database *db.DB) tea.Cmd {
+	return startSyncWithProgress(manager, database)
+}
+
+func deferredIDs(ids []string, limit int) string {
+	shown := ids
+	suffix := ""
+	if len(shown) > limit {
+		shown = shown[:limit]
+		suffix = fmt.Sprintf(", and %d more", len(ids)-limit)
+	}
+	return strings.Join(shown, ", ") + suffix
 }

--- a/internal/interface/tui/messages_test.go
+++ b/internal/interface/tui/messages_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -63,8 +64,23 @@ func TestSyncManagerPreventsOverlapAndAllowsRestart(t *testing.T) {
 	}
 }
 
+func TestSyncManagerOnDoneRunsAfterManagerBecomesRestartable(t *testing.T) {
+	manager := newSyncManager(context.Background())
+	defer manager.close()
+
+	restartAccepted := make(chan bool, 1)
+	if !manager.start(func(context.Context) {}, func() {
+		restartAccepted <- manager.start(func(context.Context) {}, nil)
+	}) {
+		t.Fatal("initial start() = false, want true")
+	}
+	if accepted := <-restartAccepted; !accepted {
+		t.Fatal("manager remained active when completion became observable")
+	}
+}
+
 func TestChannelProgressReporterDoesNotBlockWhenFull(t *testing.T) {
-	progressCh := make(chan syncProgressMsg, 1)
+	progressCh := make(chan syncEvent, 2)
 	reporter := &channelProgressReporter{ch: progressCh}
 	reporter.send()
 
@@ -82,7 +98,7 @@ func TestChannelProgressReporterDoesNotBlockWhenFull(t *testing.T) {
 }
 
 func TestChannelProgressReporterScopesEachProvider(t *testing.T) {
-	progressCh := make(chan syncProgressMsg, 5)
+	progressCh := make(chan syncEvent, 6)
 	reporter := &channelProgressReporter{ch: progressCh}
 
 	reporter.beginSource("claude", 2)
@@ -103,10 +119,23 @@ func TestChannelProgressReporterScopesEachProvider(t *testing.T) {
 		{provider: "amp", current: 1, total: 1},
 	}
 	for index, expected := range want {
-		got := <-progressCh
+		got := (<-progressCh).progress
 		if got.provider != expected.provider || got.current != expected.current || got.total != expected.total {
 			t.Fatalf("progress message %d = %+v, want provider %q at %d/%d", index, got, expected.provider, expected.current, expected.total)
 		}
+	}
+}
+
+func TestChannelProgressReporterCompletionCarriesWarningsWhenFull(t *testing.T) {
+	progressCh := make(chan syncEvent, 1)
+	reporter := &channelProgressReporter{ch: progressCh}
+	reporter.send()
+	reporter.complete([]string{"amp sync timed out"})
+
+	msg := syncSubscribe(progressCh)()
+	finished, ok := msg.(syncFinishedMsg)
+	if !ok || !reflect.DeepEqual(finished.warnings, []string{"amp sync timed out"}) {
+		t.Fatalf("completion message = %#v, want visible sync warning", msg)
 	}
 }
 
@@ -170,7 +199,7 @@ func TestApplySessionsRestoresSelectedSessionByID(t *testing.T) {
 	}
 }
 
-func TestSyncFinishedReloadsBeforeReturning(t *testing.T) {
+func TestSyncFinishedReloadsAsynchronouslyAndShowsWarnings(t *testing.T) {
 	database, err := db.New(filepath.Join(t.TempDir(), "sync-finished.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -179,11 +208,19 @@ func TestSyncFinishedReloadsBeforeReturning(t *testing.T) {
 
 	model := NewWithContext(context.Background(), database)
 	defer model.Close()
-	updated, cmd := model.Update(syncFinishedMsg{})
-	if cmd != nil {
-		t.Fatal("syncFinishedMsg returned asynchronous command, want owned synchronous reload")
+	updated, cmd := model.Update(syncFinishedMsg{warnings: []string{"amp sync timed out"}})
+	if cmd == nil {
+		t.Fatal("syncFinishedMsg returned nil command, want asynchronous reload")
 	}
-	if updated.(Model).syncing {
+	got := updated.(Model)
+	if got.syncing {
 		t.Fatal("syncing remains true after synchronous reload")
+	}
+	if !strings.Contains(got.View(), "amp sync timed out") {
+		t.Fatalf("View() = %q, want user-visible sync warning", got.View())
+	}
+	loaded, ok := cmd().(sessionsLoadedMsg)
+	if !ok || !loaded.restoreSelection {
+		t.Fatalf("reload message = %#v, want selection-restoring session load", loaded)
 	}
 }

--- a/internal/interface/tui/messages_test.go
+++ b/internal/interface/tui/messages_test.go
@@ -1,0 +1,144 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/neilberkman/ccrider/internal/core/db"
+)
+
+func TestSyncManagerCloseCancelsAndWaits(t *testing.T) {
+	manager := newSyncManager(context.Background())
+	started := make(chan struct{})
+	finished := make(chan struct{})
+
+	if !manager.start(func(ctx context.Context) {
+		close(started)
+		<-ctx.Done()
+		close(finished)
+	}, nil) {
+		t.Fatal("start() = false, want true")
+	}
+	<-started
+
+	manager.close()
+
+	select {
+	case <-finished:
+	default:
+		t.Fatal("close() returned before active work finished")
+	}
+	if manager.start(func(context.Context) {}, nil) {
+		t.Fatal("start() after close = true, want false")
+	}
+}
+
+func TestSyncManagerPreventsOverlapAndAllowsRestart(t *testing.T) {
+	manager := newSyncManager(context.Background())
+	defer manager.close()
+
+	release := make(chan struct{})
+	done := make(chan struct{})
+	if !manager.start(func(context.Context) {
+		<-release
+		close(done)
+	}, nil) {
+		t.Fatal("first start() = false, want true")
+	}
+	if manager.start(func(context.Context) {}, nil) {
+		t.Fatal("overlapping start() = true, want false")
+	}
+	close(release)
+	<-done
+
+	deadline := time.Now().Add(time.Second)
+	for !manager.start(func(context.Context) {}, nil) {
+		if time.Now().After(deadline) {
+			t.Fatal("start() remained false after previous work completed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestChannelProgressReporterDoesNotBlockWhenFull(t *testing.T) {
+	progressCh := make(chan syncProgressMsg, 1)
+	reporter := &channelProgressReporter{ch: progressCh}
+	reporter.send()
+
+	done := make(chan struct{})
+	go func() {
+		reporter.send()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("send() blocked on a full progress channel")
+	}
+}
+
+func TestSessionsLoadedMessageIgnoresStaleGeneration(t *testing.T) {
+	model := Model{
+		sessions:               []sessionItem{{ID: "current"}},
+		sessionsLoadGeneration: 2,
+	}
+
+	updated, _ := model.Update(sessionsLoadedMsg{
+		sessions:   []sessionItem{{ID: "stale"}},
+		generation: 1,
+	})
+	got := updated.(Model)
+	if len(got.sessions) != 1 || got.sessions[0].ID != "current" {
+		t.Fatalf("stale load replaced sessions: %+v", got.sessions)
+	}
+}
+
+func TestSessionsLoadFailureIgnoresStaleGeneration(t *testing.T) {
+	model := Model{sessionsLoadGeneration: 2}
+	staleErr := context.Canceled
+
+	updated, _ := model.Update(sessionsLoadFailedMsg{err: staleErr, generation: 1})
+	if got := updated.(Model).err; got != nil {
+		t.Fatalf("stale load error replaced current state: %v", got)
+	}
+}
+
+func TestApplySessionsRestoresSelectedSessionByID(t *testing.T) {
+	model := Model{
+		width:            80,
+		height:           24,
+		savedCursorIndex: 1,
+		savedSessionID:   "selected",
+	}
+	model.applySessions([]sessionItem{
+		{ID: "new"},
+		{ID: "other"},
+		{ID: "selected"},
+	}, true)
+
+	selected, ok := model.list.SelectedItem().(sessionListItem)
+	if !ok || selected.session.ID != "selected" {
+		t.Fatalf("selected item = %#v, want selected session ID", model.list.SelectedItem())
+	}
+}
+
+func TestSyncFinishedReloadsBeforeReturning(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "sync-finished.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+
+	model := NewWithContext(context.Background(), database)
+	defer model.Close()
+	updated, cmd := model.Update(syncFinishedMsg{})
+	if cmd != nil {
+		t.Fatal("syncFinishedMsg returned asynchronous command, want owned synchronous reload")
+	}
+	if updated.(Model).syncing {
+		t.Fatal("syncing remains true after synchronous reload")
+	}
+}

--- a/internal/interface/tui/messages_test.go
+++ b/internal/interface/tui/messages_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +78,50 @@ func TestChannelProgressReporterDoesNotBlockWhenFull(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("send() blocked on a full progress channel")
+	}
+}
+
+func TestChannelProgressReporterScopesEachProvider(t *testing.T) {
+	progressCh := make(chan syncProgressMsg, 5)
+	reporter := &channelProgressReporter{ch: progressCh}
+
+	reporter.beginSource("claude", 2)
+	reporter.Update("first", "")
+	reporter.Update("second", "")
+	reporter.beginSource("amp", 1)
+	reporter.Skip()
+
+	want := []struct {
+		provider string
+		current  int
+		total    int
+	}{
+		{provider: "claude", current: 0, total: 2},
+		{provider: "claude", current: 1, total: 2},
+		{provider: "claude", current: 2, total: 2},
+		{provider: "amp", current: 0, total: 1},
+		{provider: "amp", current: 1, total: 1},
+	}
+	for index, expected := range want {
+		got := <-progressCh
+		if got.provider != expected.provider || got.current != expected.current || got.total != expected.total {
+			t.Fatalf("progress message %d = %+v, want provider %q at %d/%d", index, got, expected.provider, expected.current, expected.total)
+		}
+	}
+}
+
+func TestViewListNamesSyncProvider(t *testing.T) {
+	model := Model{
+		initialLoad:  false,
+		syncing:      true,
+		syncProvider: "amp",
+		syncCurrent:  1,
+		syncTotal:    2,
+		width:        80,
+	}
+
+	if got := model.viewList(); !strings.Contains(got, "Syncing amp") {
+		t.Fatalf("viewList() = %q, want provider-scoped sync status", got)
 	}
 }
 

--- a/internal/interface/tui/model.go
+++ b/internal/interface/tui/model.go
@@ -89,6 +89,7 @@ type Model struct {
 	// Sync progress state
 	syncing                bool
 	syncCurrentFile        string
+	syncProvider           string
 	syncTotal              int
 	syncCurrent            int
 	savedCursorIndex       int // Preserve cursor position during sync
@@ -352,6 +353,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncing = true // Set syncing flag so progress bar shows
 		m.syncCurrent = msg.current
 		m.syncTotal = msg.total
+		m.syncProvider = msg.provider
 		m.syncCurrentFile = msg.sessionName
 		// Chain another command to keep waiting for progress via channel
 		return m, syncSubscribe(msg.ch)

--- a/internal/interface/tui/model.go
+++ b/internal/interface/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -25,13 +26,14 @@ const (
 )
 
 type Model struct {
-	db       *db.DB
-	mode     viewMode
-	list     list.Model
-	viewport viewport.Model
-	width    int
-	height   int
-	err      error
+	db          *db.DB
+	syncManager *syncManager
+	mode        viewMode
+	list        list.Model
+	viewport    viewport.Model
+	width       int
+	height      int
+	err         error
 
 	// Current session data
 	sessions       []sessionItem
@@ -85,11 +87,13 @@ type Model struct {
 	initialLoad bool // True until first sessionsLoadedMsg arrives
 
 	// Sync progress state
-	syncing          bool
-	syncCurrentFile  string
-	syncTotal        int
-	syncCurrent      int
-	savedCursorIndex int // Preserve cursor position during sync
+	syncing                bool
+	syncCurrentFile        string
+	syncTotal              int
+	syncCurrent            int
+	savedCursorIndex       int // Preserve cursor position during sync
+	savedSessionID         string
+	sessionsLoadGeneration uint64
 }
 
 type sessionItem struct {
@@ -137,6 +141,14 @@ type matchOccurrenceInfo struct {
 }
 
 func New(database *db.DB) Model {
+	return NewWithContext(context.Background(), database)
+}
+
+// NewWithContext creates a model whose background syncs stop when ctx does.
+func NewWithContext(ctx context.Context, database *db.DB) Model {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	ti := textinput.New()
 	ti.Placeholder = "Search messages..."
 	ti.Focus()
@@ -161,16 +173,35 @@ func New(database *db.DB) Model {
 	currentDir, _ := os.Getwd()
 
 	return Model{
-		db:                   database,
-		mode:                 listView,
-		list:                 emptyList,
-		searchInput:          ti,
-		inSessionSearch:      inSessionTi,
-		exportInput:          exportTi,
-		projectFilterEnabled: false, // Disabled by default
-		currentDirectory:     currentDir,
-		initialLoad:          true, // True until first sessionsLoadedMsg
-		syncing:              true, // Start with syncing=true
+		db:                     database,
+		syncManager:            newSyncManager(ctx),
+		mode:                   listView,
+		list:                   emptyList,
+		searchInput:            ti,
+		inSessionSearch:        inSessionTi,
+		exportInput:            exportTi,
+		projectFilterEnabled:   false, // Disabled by default
+		currentDirectory:       currentDir,
+		initialLoad:            true, // True until first sessionsLoadedMsg
+		syncing:                true, // Start with syncing=true
+		sessionsLoadGeneration: 1,
+	}
+}
+
+func (m *Model) applySessions(sessions []sessionItem, restoreSelection bool) {
+	m.sessions = sessions
+	m.list = createSessionList(sessions, m.width, m.height)
+	if !restoreSelection {
+		return
+	}
+	for index, session := range sessions {
+		if session.ID == m.savedSessionID {
+			m.list.Select(index)
+			return
+		}
+	}
+	if m.savedCursorIndex >= 0 && m.savedCursorIndex < len(sessions) {
+		m.list.Select(m.savedCursorIndex)
 	}
 }
 
@@ -186,9 +217,16 @@ func (m Model) Init() tea.Cmd {
 	}
 
 	return tea.Batch(
-		loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory),
-		syncSessions(m.db, m.projectFilterEnabled, m.currentDirectory),
+		loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration),
+		syncSessions(m.syncManager, m.db),
 	)
+}
+
+// Close cancels and joins any active sync before its database is closed.
+func (m Model) Close() {
+	if m.syncManager != nil {
+		m.syncManager.close()
+	}
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -316,22 +354,38 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncTotal = msg.total
 		m.syncCurrentFile = msg.sessionName
 		// Chain another command to keep waiting for progress via channel
-		return m, syncSubscribe(msg.ch, msg.db, msg.filterByProject, msg.projectPath)
+		return m, syncSubscribe(msg.ch)
 
 	case sessionsLoadedMsg:
-		m.initialLoad = false
-		m.sessions = msg.sessions
-		m.list = createSessionList(msg.sessions, m.width, m.height)
-
-		// If we were syncing, restore cursor position and clear sync flag
-		if m.syncing {
-			m.syncing = false
-			// Restore cursor position if valid
-			if m.savedCursorIndex >= 0 && m.savedCursorIndex < len(msg.sessions) {
-				m.list.Select(m.savedCursorIndex)
-			}
+		if msg.generation != m.sessionsLoadGeneration {
+			return m, nil
 		}
+		m.initialLoad = false
+		m.applySessions(msg.sessions, false)
 		return m, nil
+
+	case sessionsLoadFailedMsg:
+		if msg.generation != m.sessionsLoadGeneration {
+			return m, nil
+		}
+		m.err = msg.err
+		return m, nil
+
+	case syncFinishedMsg:
+		m.sessionsLoadGeneration++
+		loaded := loadSessionsNow(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration)
+		m.syncing = false
+		switch loaded := loaded.(type) {
+		case sessionsLoadedMsg:
+			m.initialLoad = false
+			m.applySessions(loaded.sessions, true)
+			return m, nil
+		case sessionsLoadFailedMsg:
+			m.err = loaded.err
+			return m, nil
+		default:
+			return m, nil
+		}
 
 	case sessionDetailLoadedMsg:
 		m.currentSession = &msg.detail

--- a/internal/interface/tui/model.go
+++ b/internal/interface/tui/model.go
@@ -218,7 +218,7 @@ func (m Model) Init() tea.Cmd {
 	}
 
 	return tea.Batch(
-		loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration),
+		loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration, false),
 		syncSessions(m.syncManager, m.db),
 	)
 }
@@ -363,7 +363,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.initialLoad = false
-		m.applySessions(msg.sessions, false)
+		m.applySessions(msg.sessions, msg.restoreSelection)
 		return m, nil
 
 	case sessionsLoadFailedMsg:
@@ -375,19 +375,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case syncFinishedMsg:
 		m.sessionsLoadGeneration++
-		loaded := loadSessionsNow(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration)
 		m.syncing = false
-		switch loaded := loaded.(type) {
-		case sessionsLoadedMsg:
-			m.initialLoad = false
-			m.applySessions(loaded.sessions, true)
-			return m, nil
-		case sessionsLoadFailedMsg:
-			m.err = loaded.err
-			return m, nil
-		default:
-			return m, nil
+		if len(msg.warnings) > 0 {
+			m.statusMsg = "Sync completed with warnings:\n\n- " + strings.Join(msg.warnings, "\n- ")
 		}
+		return m, loadSessions(m.db, m.projectFilterEnabled, m.currentDirectory, m.sessionsLoadGeneration, true)
 
 	case sessionDetailLoadedMsg:
 		m.currentSession = &msg.detail


### PR DESCRIPTION
## Summary

Amp sync previously shared a fixed two-minute budget across thread listing and every changed-thread export. Large accounts could stop partway through and report untouched threads as individual `context deadline exceeded` failures.

This keeps Amp's 30-second per-command deadline while moving the overall lifetime to the interfaces that own the operation:

- `ccrider sync` now has a 10-minute per-remote-provider default via `--sync-timeout`; `--sync-timeout=0` disables the overall bound.
- The TUI applies the same remote-provider bound, cancels sync on shutdown, and joins active sync work before closing the database.
- Local providers remain outside the remote timeout budget.

Interrupted imports now distinguish work accurately:

- Changed or unexamined sessions are deferred with their thread IDs retained for diagnosis.
- Known unchanged sessions remain skipped rather than being counted as deferred.
- Both `context.Canceled` and `context.DeadlineExceeded` produce consistent accounting.
- `SyncAll` returns an incomplete-sync signal, including when interruption happens during remote listing.

Amp subprocess handling also accepts complete stdout when the main process exits successfully but descendants keep pipes open long enough to produce `exec.ErrWaitDelay`. Caller cancellation or deadline still takes precedence.

## TUI lifecycle safeguards

The TUI now:

- Prevents overlapping manual syncs.
- Uses nonblocking progress delivery so shutdown cannot deadlock.
- Ignores stale session-load results and stale load errors.
- Reloads the final post-sync list inside the owned completion path before database shutdown.
- Restores the selected session by ID rather than by a potentially shifted list index.

## Validation

Real account validation with 135 Amp threads using the review-fixed binary:

| Run | Duration | Imported | Unchanged | Failures |
| --- | ---: | ---: | ---: | ---: |
| Incremental run | 23.6s | 7 | 128 | 0 |
| Immediate rerun | 2ms | 0 | 135 | 0 |

Earlier initial-import validation also completed all 133 listed threads beyond the former two-minute cutoff, importing 81, skipping 47 unchanged, and reporting only 5 genuine export failures.

Checks completed:

- `make test` (race-enabled)
- `make lint`
- `go vet ./...`
- `go build ./cmd/ccrider`
- `git diff --check`
